### PR TITLE
Full smoke test

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,7 +27,7 @@ use_plugin("python.vendorize")
 use_plugin("filter_resources")
 
 name = "kubernator"
-version = "1.0.8"
+version = "1.0.9.dev"
 
 summary = "Kubernator is the a pluggable framework for K8S provisioning"
 authors = [Author("Express Systems USA, Inc.", "")]

--- a/src/integrationtest/python/full_smoke/.kubernator.py
+++ b/src/integrationtest/python/full_smoke/.kubernator.py
@@ -1,0 +1,15 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ["START_FRESH"]),
+                         keep_running=bool(os.environ["KEEP_RUNNING"]),
+                         profile="full-smoke")
+ktor.app.register_plugin("awscli")
+ktor.app.register_plugin("terraform", version="1.5.7")
+ktor.app.register_plugin("terragrunt", version="0.48.0")
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("kubectl")
+ktor.app.register_plugin("istio", version=os.environ["ISTIO_VERSION"])
+ktor.app.register_plugin("helm", version="3.13.2")
+ktor.app.register_plugin("templates")

--- a/src/integrationtest/python/full_smoke_tests.py
+++ b/src/integrationtest/python/full_smoke_tests.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+import os  # noqa: E402
+
+
+class FullSmokeTest(IntegrationTestSupport):
+    def test_full_smoke(self):
+        test_dir = Path(__file__).parent / "full_smoke"
+
+        for k8s_version, istio_version in ((self.K8S_TEST_VERSIONS[0], "1.10.6"),
+                                           (self.K8S_TEST_VERSIONS[-1], "1.20.0")):
+            with self.subTest(k8s_version=k8s_version, istio_version=istio_version):
+                os.environ["K8S_VERSION"] = k8s_version
+                os.environ["ISTIO_VERSION"] = istio_version
+                os.environ["START_FRESH"] = "1"
+                os.environ["KEEP_RUNNING"] = "1"
+
+                self.run_module_test("kubernator", "-p", str(test_dir))
+                os.environ["START_FRESH"] = ""
+                self.run_module_test("kubernator", "-p", str(test_dir), "dump")
+                self.run_module_test("kubernator", "-p", str(test_dir), "apply")
+                os.environ["KEEP_RUNNING"] = ""
+                self.run_module_test("kubernator", "-p", str(test_dir), "apply", "--yes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/kubernator/api.py
+++ b/src/main/python/kubernator/api.py
@@ -235,8 +235,8 @@ def install_python_k8s_client(run, package_major, logger_stdout, logger_stderr):
     if not package_major_dir.exists():
         package_major_dir.mkdir(parents=True, exist_ok=True)
 
-        run(["pip", "install", "--no-deps", "--no-cache-dir", "--no-input", "--target", str(package_major_dir),
-             f"kubernetes~={package_major}.0"], logger_stdout, logger_stderr).wait()
+        run([sys.executable, "-m", "pip", "install", "--no-deps", "--no-cache-dir", "--no-input", "--pre",
+             "--target", str(package_major_dir), f"kubernetes~={package_major}.0"], logger_stdout, logger_stderr).wait()
 
     return package_major_dir
 

--- a/src/main/python/kubernator/plugins/helm.py
+++ b/src/main/python/kubernator/plugins/helm.py
@@ -124,6 +124,7 @@ class HelmPlugin(KubernatorPlugin):
             helm_file_dl, _ = context.app.download_remote_file(logger, helm_url, "bin")
             helm_file_dl = str(helm_file_dl)
             self.helm_dir = tempfile.TemporaryDirectory()
+            context.app.register_cleanup(self.helm_dir)
 
             helm_file = str(Path(self.helm_dir.name) / "helm")
             helm_tar = tarfile.open(helm_file_dl)

--- a/src/main/python/kubernator/plugins/istio.py
+++ b/src/main/python/kubernator/plugins/istio.py
@@ -71,6 +71,7 @@ class IstioPlugin(KubernatorPlugin, K8SResourcePluginMixin):
             istioctl_file_dl, _ = context.app.download_remote_file(logger, istioctl_url, "bin")
             istioctl_file_dl = str(istioctl_file_dl)
             self.istioctl_dir = tempfile.TemporaryDirectory()
+            context.app.register_cleanup(self.istioctl_dir)
 
             istioctl_file = str(Path(self.istioctl_dir.name) / "istioctl")
             istio_tar = tarfile.open(istioctl_file_dl)

--- a/src/main/python/kubernator/plugins/minikube.py
+++ b/src/main/python/kubernator/plugins/minikube.py
@@ -111,6 +111,8 @@ class MinikubePlugin(KubernatorPlugin):
 
         os.chmod(minikube_dl_file, 0o500)
         self.minikube_dir = tempfile.TemporaryDirectory()
+        context.app.register_cleanup(self.minikube_dir)
+
         minikube_file = Path(self.minikube_dir.name) / "minikube"
         minikube_file.symlink_to(minikube_dl_file)
         prepend_os_path(self.minikube_dir.name)

--- a/src/main/python/kubernator/plugins/terraform.py
+++ b/src/main/python/kubernator/plugins/terraform.py
@@ -65,6 +65,7 @@ class TerraformPlugin(KubernatorPlugin):
             tf_file_dl, _ = context.app.download_remote_file(logger, tf_url, "bin")
             tf_file_dl = str(tf_file_dl)
             self.tf_dir = tempfile.TemporaryDirectory()
+            context.app.register_cleanup(self.tf_dir)
 
             tf_file = str(Path(self.tf_dir.name) / "terraform")
             tf_zip = zipfile.ZipFile(tf_file_dl)

--- a/src/main/python/kubernator/plugins/terragrunt.py
+++ b/src/main/python/kubernator/plugins/terragrunt.py
@@ -63,6 +63,8 @@ class TerragruntPlugin(KubernatorPlugin):
             tg_file_cache, _ = context.app.download_remote_file(logger, tg_url, "bin")
 
             self.tg_dir = tempfile.TemporaryDirectory()
+            context.app.register_cleanup(self.tg_dir)
+
             tg_file = Path(self.tg_dir.name) / "terragrunt"
             copy(tg_file_cache, tg_file)
             os.chmod(tg_file, 0o500)


### PR DESCRIPTION
Cleanup temporary directories
Kubectl is now driven by the context.k8s.server_version if version is blank