### PR TITLE
Fix unquoted `equals sign` in YAML documents having special meaning

### DIFF
--- a/src/main/python/kubernator/app.py
+++ b/src/main/python/kubernator/app.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Optional, Union
 
+import yaml
+
 import kubernator
 from kubernator.api import (KubernatorPlugin, Globs, scan_dir, PropertyDict, config_as_dict, config_parent,
                             download_remote_file, load_remote_file, Repository, StripNL, jp, get_app_cache_dir,
@@ -54,6 +56,11 @@ def trace(self, msg, *args, **kwargs):
 logging.addLevelName(5, "TRACE")
 logging.Logger.trace = trace
 logger = logging.getLogger("kubernator")
+
+try:
+    del (yaml.resolver.Resolver.yaml_implicit_resolvers["="])
+except KeyError:
+    pass
 
 
 def define_arg_parse():

--- a/src/unittest/python/issue55_tests.py
+++ b/src/unittest/python/issue55_tests.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2024 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from io import StringIO
+from textwrap import dedent
+
+
+class Issue55Testcase(unittest.TestCase):
+    def test_issue55(self):
+        from kubernator.app import yaml
+        source = dedent("""
+        enum:
+        - '!='
+        - =
+        - =~
+        - '!~'
+        type: string
+        """)
+        yaml_doc = yaml.safe_load(StringIO(source))
+        self.assertEqual(yaml_doc["enum"], ["!=", "=", "=~", "!~"])
+
+        import yaml
+        yaml_doc = yaml.safe_load(StringIO(source))
+        self.assertEqual(yaml_doc["enum"], ["!=", "=", "=~", "!~"])


### PR DESCRIPTION
fixes #55