### PR TITLE
Add support for Helm OCI-based charts

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,7 +27,7 @@ use_plugin("python.vendorize")
 use_plugin("filter_resources")
 
 name = "kubernator"
-version = "1.0.19"
+version = "1.0.20.dev"
 
 summary = "Kubernator is the a pluggable framework for K8S provisioning"
 authors = [Author("Express Systems USA, Inc.", "")]

--- a/src/integrationtest/issue_72/.kubernator.py
+++ b/src/integrationtest/issue_72/.kubernator.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ["START_FRESH"]),
+                         keep_running=bool(os.environ["KEEP_RUNNING"]),
+                         profile="issue-68")
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("istio", version=os.environ["ISTIO_VERSION"])
+ktor.app.register_plugin("templates")
+

--- a/src/integrationtest/python/issue_72/invalid-oci/.kubernator.py
+++ b/src/integrationtest/python/issue_72/invalid-oci/.kubernator.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ["START_FRESH"]),
+                         keep_running=bool(os.environ["KEEP_RUNNING"]),
+                         profile="issue-72")
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("helm", version=os.environ["HELM_VERSION"])
+ktor.app.register_plugin("templates")
+

--- a/src/integrationtest/python/issue_72/invalid-oci/oci-test.helm.yaml
+++ b/src/integrationtest/python/issue_72/invalid-oci/oci-test.helm.yaml
@@ -1,0 +1,4 @@
+repository: test-repo-doesnt-exist
+chart: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+name: arc
+namespace: arc-systems

--- a/src/integrationtest/python/issue_72/invalid-repo/.kubernator.py
+++ b/src/integrationtest/python/issue_72/invalid-repo/.kubernator.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ["START_FRESH"]),
+                         keep_running=bool(os.environ["KEEP_RUNNING"]),
+                         profile="issue-72")
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("helm", version=os.environ["HELM_VERSION"])
+ktor.app.register_plugin("templates")
+

--- a/src/integrationtest/python/issue_72/invalid-repo/repo-test.helm.yaml
+++ b/src/integrationtest/python/issue_72/invalid-repo/repo-test.helm.yaml
@@ -1,0 +1,4 @@
+repository: https://kubernetes-sigs.github.io/metrics-server
+chart: metrics-server
+name: metrics-server
+namespace: kube-system

--- a/src/integrationtest/python/issue_72/valid/.kubernator.py
+++ b/src/integrationtest/python/issue_72/valid/.kubernator.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ["START_FRESH"]),
+                         keep_running=bool(os.environ["KEEP_RUNNING"]),
+                         profile="issue-72")
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("helm", version=os.environ["HELM_VERSION"])
+ktor.app.register_plugin("templates")
+

--- a/src/integrationtest/python/issue_72/valid/oci-test.helm.yaml
+++ b/src/integrationtest/python/issue_72/valid/oci-test.helm.yaml
@@ -1,0 +1,3 @@
+chart: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+name: arc
+namespace: arc-systems

--- a/src/integrationtest/python/issue_72/valid/repo-test.helm.yaml
+++ b/src/integrationtest/python/issue_72/valid/repo-test.helm.yaml
@@ -1,0 +1,5 @@
+repository: https://kubernetes-sigs.github.io/metrics-server
+chart: metrics-server
+version: 3.12.2
+name: metrics-server
+namespace: kube-system

--- a/src/integrationtest/python/issue_72_tests.py
+++ b/src/integrationtest/python/issue_72_tests.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+import os  # noqa: E402
+
+
+class Issue72Test(IntegrationTestSupport):
+    def test_issue_72_helm_valid(self):
+        test_dir = Path(__file__).parent / "issue_72" / "valid"
+
+        os.environ["START_FRESH"] = "1"
+        os.environ["KEEP_RUNNING"] = ""
+        os.environ["K8S_VERSION"] = "1.31.5"
+        os.environ["HELM_VERSION"] = "3.17.3"
+        self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "dump")
+
+    def test_issue_72_helm_invalid_oci(self):
+        test_dir = Path(__file__).parent / "issue_72" / "invalid-oci"
+
+        os.environ["START_FRESH"] = "1"
+        os.environ["KEEP_RUNNING"] = ""
+        os.environ["K8S_VERSION"] = "1.31.5"
+        os.environ["HELM_VERSION"] = "3.17.3"
+        with self.assertRaises(AssertionError):
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "dump")
+
+    def test_issue_72_helm_invalid_repo(self):
+        test_dir = Path(__file__).parent / "issue_72" / "invalid-repo"
+
+        os.environ["START_FRESH"] = "1"
+        os.environ["KEEP_RUNNING"] = ""
+        os.environ["K8S_VERSION"] = "1.31.5"
+        os.environ["HELM_VERSION"] = "3.17.3"
+        with self.assertRaises(AssertionError):
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "dump")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/test_support.py
+++ b/src/integrationtest/python/test_support.py
@@ -83,3 +83,13 @@ class IntegrationTestSupport(unittest.TestCase):
             sys.path.extend(old_sys_path)
 
             chdir(old_cwd)
+
+            from logging import shutdown, _handlerList, root
+
+            shutdown()
+
+            import gc
+            gc.collect()
+            root.handlers.clear()
+            _handlerList.clear()
+            gc.collect()


### PR DESCRIPTION
Repository is no longer required if OCI-based chart is used 
Version is no longer required if OCI-based chart is used

fixes #72