### PR TITLE
Add testing for K8S 1.33.x and Istio 1.26.x

### DIFF
--- a/src/integrationtest/python/full_smoke_tests.py
+++ b/src/integrationtest/python/full_smoke_tests.py
@@ -28,8 +28,10 @@ class FullSmokeTest(IntegrationTestSupport):
     def test_full_smoke(self):
         test_dir = Path(__file__).parent / "full_smoke"
 
-        for k8s_version, istio_version in ((self.K8S_TEST_VERSIONS[0], "1.10.6"),
-                                           (self.K8S_TEST_VERSIONS[-1], "1.25.2")):
+        for k8s_version, istio_version in ((self.K8S_TEST_VERSIONS[-4], "1.23.6"),
+                                           (self.K8S_TEST_VERSIONS[-3], "1.24.6"),
+                                           (self.K8S_TEST_VERSIONS[-2], "1.25.3"),
+                                           (self.K8S_TEST_VERSIONS[-1], "1.26.0")):
             with self.subTest(k8s_version=k8s_version, istio_version=istio_version):
                 os.environ["K8S_VERSION"] = k8s_version
                 os.environ["ISTIO_VERSION"] = istio_version

--- a/src/integrationtest/python/test_support.py
+++ b/src/integrationtest/python/test_support.py
@@ -35,8 +35,8 @@ class IntegrationTestSupport(unittest.TestCase):
     K8S_TEST_VERSIONS = ["1.20.15", "1.21.14", "1.22.17",
                          "1.23.17", "1.24.17", "1.25.16",
                          "1.26.15", "1.27.16", "1.28.15",
-                         "1.29.15", "1.30.12", "1.31.8",
-                         "1.32.4"]
+                         "1.29.15", "1.30.13", "1.31.9",
+                         "1.32.5", "1.33.1"]
 
     def load_json_logs(self, log_file):
         decoder = json.JSONDecoder()


### PR DESCRIPTION
Start testing last 4 versions of Istio with last 4 versions of K8S