### PR TITLE
Add kindest-node-release workflow

### DIFF
--- a/.github/workflows/kindest-node-release.yml
+++ b/.github/workflows/kindest-node-release.yml
@@ -5,6 +5,11 @@ on:
     - cron: '17 * * * *'
   workflow_dispatch:
 
+# Hard guard: never run on pull_request (or any other trigger we haven't
+# explicitly opted into). If a future change adds pull_request to `on:`,
+# this condition prevents it from publishing to GHCR.
+run-name: kindest-node-release (${{ github.event_name }})
+
 permissions:
   packages: write
   contents: read
@@ -16,6 +21,7 @@ env:
 jobs:
   discover:
     name: Discover missing versions
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.diff.outputs.versions }}
@@ -74,7 +80,9 @@ jobs:
   build:
     name: Build ${{ matrix.version }} (${{ matrix.arch }})
     needs: discover
-    if: needs.discover.outputs.count != '0'
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && needs.discover.outputs.count != '0'
     strategy:
       fail-fast: false
       matrix:
@@ -116,7 +124,9 @@ jobs:
   manifest:
     name: Multi-arch manifest ${{ matrix.version }}
     needs: [discover, build]
-    if: needs.discover.outputs.count != '0'
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && needs.discover.outputs.count != '0'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/kindest-node-release.yml
+++ b/.github/workflows/kindest-node-release.yml
@@ -1,0 +1,139 @@
+name: kindest-node-release
+on:
+  schedule:
+    # Hourly at :17 to avoid the top-of-hour thundering herd.
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+env:
+  REGISTRY: ghcr.io/karellen/kindest-node
+  KIND_FLOOR_MINOR: 29
+
+jobs:
+  discover:
+    name: Discover missing versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.diff.outputs.versions }}
+      count: ${{ steps.diff.outputs.count }}
+    steps:
+      - name: List upstream K8s tags
+        id: upstream
+        run: |
+          set -euo pipefail
+          git ls-remote --tags --refs https://github.com/kubernetes/kubernetes 'v1.*' \
+            | awk '{print $2}' \
+            | sed 's|^refs/tags/v||' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | awk -F. -v floor="${KIND_FLOOR_MINOR}" '$1 == 1 && $2 >= floor' \
+            | sort -u > upstream.txt
+          echo "upstream count: $(wc -l < upstream.txt)"
+
+      - name: List existing GHCR tags
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          : > existing.txt
+          # Try org first, fall back to user. If package doesn't exist yet, proceed with empty list.
+          for owner_kind in orgs users; do
+            if gh api -H "Accept: application/vnd.github+json" \
+                 "/${owner_kind}/karellen/packages/container/kindest-node/versions" \
+                 --paginate --jq '.[].metadata.container.tags[]' 2>/dev/null \
+               | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+               | sed 's/^v//' \
+               | sort -u > existing.txt; then
+              break
+            fi
+          done
+          echo "existing count: $(wc -l < existing.txt)"
+
+      - name: Compute diff
+        id: diff
+        run: |
+          set -euo pipefail
+          comm -23 upstream.txt existing.txt > todo.txt
+          count=$(wc -l < todo.txt | tr -d ' ')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          if [[ "${count}" == "0" ]]; then
+            echo "versions=[]" >> "$GITHUB_OUTPUT"
+            echo "Nothing to build."
+            exit 0
+          fi
+          # Emit JSON array for matrix.
+          jq -R . < todo.txt | jq -sc . > versions.json
+          echo "versions=$(cat versions.json)" >> "$GITHUB_OUTPUT"
+          echo "Versions to build:"
+          cat todo.txt
+
+  build:
+    name: Build ${{ matrix.version }} (${{ matrix.arch }})
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.discover.outputs.versions) }}
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    steps:
+      - name: Install kind
+        run: |
+          set -euo pipefail
+          KIND_VERSION=$(git ls-remote --tags --refs https://github.com/kubernetes-sigs/kind 'v*' \
+            | awk '{print $2}' \
+            | sed 's|^refs/tags/v||' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+          echo "Using kind v${KIND_VERSION}"
+          curl -fsSL -o /usr/local/bin/kind \
+            "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-${{ matrix.arch }}"
+          chmod +x /usr/local/bin/kind
+          kind version
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build kindest/node v${{ matrix.version }} (${{ matrix.arch }})
+        run: |
+          set -euo pipefail
+          kind build node-image --image "${REGISTRY}:v${{ matrix.version }}-${{ matrix.arch }}" \
+            --type release "v${{ matrix.version }}"
+
+      - name: Push
+        run: |
+          docker push "${REGISTRY}:v${{ matrix.version }}-${{ matrix.arch }}"
+
+  manifest:
+    name: Multi-arch manifest ${{ matrix.version }}
+    needs: [discover, build]
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.discover.outputs.versions) }}
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${REGISTRY}:v${{ matrix.version }}" \
+            "${REGISTRY}:v${{ matrix.version }}-amd64" \
+            "${REGISTRY}:v${{ matrix.version }}-arm64"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that publishes multi-arch (amd64+arm64) `kindest/node` images to `ghcr.io/karellen/kindest-node` for every upstream Kubernetes release `>= 1.29.0`. No human-editable version list — the workflow discovers missing versions by diffing upstream `kubernetes/kubernetes` tags against existing GHCR tags and building only what's missing.

### How it works

- **Triggers**: hourly `schedule` (at :17 to avoid top-of-hour congestion) and `workflow_dispatch`. **Never** runs on `pull_request` or any other event; jobs have explicit `if` guards enforcing this even if a future change adds a new trigger.
- **`discover`**: `git ls-remote` upstream K8s tags matching `^v1\.(>=29)\.[0-9]+$`, compare to existing `ghcr.io/karellen/kindest-node` tags via `gh api`, emit the set difference as a JSON matrix.
- **`build`** (matrix `version × arch`): each version × arch runs on its native runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64), installs the latest `kind`, runs `kind build node-image --type release vX.Y.Z`, and pushes `:vX.Y.Z-<arch>`.
- **`manifest`** (per version, after both arches): `docker buildx imagetools create` merges the two per-arch tags into a single multi-arch manifest `:vX.Y.Z`.

### First run

Will backfill every 1.29.0+ patch across amd64 + arm64 (~hundreds of image-builds, several hours). Subsequent runs only build the delta.

### Follow-up tasks (not in this PR)

- After first successful push, flip the `kindest-node` GHCR package visibility to **public** so external kubernator users can pull without auth.
- Consumer of these images is the upcoming kind plugin in a separate PR.

## Test plan

- [ ] Dispatch-run this workflow on the feature branch before merging; confirm the `discover` job emits a sensible version list and a couple of matrix entries succeed end-to-end
- [ ] Verify `ghcr.io/karellen/kindest-node:vX.Y.Z` manifests list both `linux/amd64` and `linux/arm64` (`docker buildx imagetools inspect`)
- [ ] Confirm the package appears under github.com/orgs/karellen/packages and can be made public
- [ ] Confirm subsequent runs (with no new upstream tags) exit cleanly at `discover` with `count=0`