### PR TITLE
Add kind plugin; migrate internal integration tests from minikube

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ PyBuilder project — standard `src/main/python`, `src/unittest/python`,
   - `api.py` — plugin-facing API (`ktor.*`), context hierarchy, Jinja env, JSON schema,
     diff-match-patch, HTTP, etc.
   - `merge.py`, `_json_path.py`, `_k8s_client_patches.py`, `proc.py` — internals
-  - `plugins/` — `awscli`, `eks`, `gke`, `helm`, `istio`, `k8s`, `k8s_api`, `kubeconfig`,
-    `kubectl`, `minikube`, `template`, `terraform`, `terragrunt`
+  - `plugins/` — `awscli`, `eks`, `gke`, `helm`, `istio`, `k8s`, `k8s_api`, `kind`,
+    `kubeconfig`, `kubectl`, `minikube`, `template`, `terraform`, `terragrunt`
 - `src/unittest/python/` — pytest-style unit tests (`*_tests.py`)
 - `src/integrationtest/python/` — cram-style integration tests, many organized by
   `issue_NN/` reproducing specific bugs

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ any), and whether Kubernator downloads that binary automatically given a version
 | `eks`        | Generates a kubeconfig for an AWS EKS cluster.                   | (via awscli) | —                |
 | `gke`        | Generates a kubeconfig for a Google GKE cluster.                 | `gcloud`     | No (must be on PATH) |
 | `minikube`   | Provisions and manages a local Minikube cluster.                 | `minikube`   | Yes              |
+| `kind`       | Provisions and manages a local kind (Kubernetes IN Docker) cluster. | `kind`    | Yes              |
 | `terraform`  | Initialises Terraform and exposes its outputs as `ktor.tf`.      | `terraform`  | Yes              |
 | `terragrunt` | Same as above, but via Terragrunt (wraps Terraform).             | `terragrunt` | Yes              |
 | `k8s`        | Core Kubernetes plugin: loads, transforms, validates, applies.   | (API server) | —                |
@@ -330,6 +331,43 @@ ktor.app.register_plugin("minikube",
   `ktor.minikube.cpus`, `ktor.minikube.extra_args`, `ktor.minikube.extra_addons`
 * `ktor.minikube.cmd(*args)` / `ktor.minikube.cmd_out(*args)`
   > Run a `minikube` subcommand, optionally capturing output.
+
+### Kind Plugin (`kind`)
+
+Drives a local kind cluster (Kubernetes IN Docker — upstream kubeadm binaries running inside Docker containers, with
+real etcd and separate control-plane components). Downloads the `kind` binary, creates a cluster, and publishes the
+exported kubeconfig to the `kubeconfig` plugin. Unlike Minikube, kind does not ship bundled addons such as CSI hostpath
+or LoadBalancer controllers — install those separately in your `.kubernator.py` if you need them, the same way you
+would on any upstream Kubernetes cluster.
+
+```python
+ktor.app.register_plugin("kind",
+                         k8s_version="1.34.0",
+                         profile="my-dev",
+                         start_fresh=True,
+                         keep_running=False,
+                         nodes=5,
+                         control_plane_nodes=3)
+```
+
+Node images default to `ghcr.io/karellen/kindest-node:v<k8s_version>` (pre-built by the `kindest-node-release` workflow
+in this repo for every K8s release ≥ 1.29.0, multi-arch amd64/arm64). Override with `node_image_registry="kindest/node"`
+to pull from upstream Docker Hub, or pass `node_image=...` for a specific image. Lifecycle maps `start`/`stop` onto
+`docker start` / `docker stop` on the node containers (kind has no native start/stop subcommands); `keep_running=False`
+stops containers without deleting them, and `start_fresh=True` deletes and recreates the cluster.
+
+Multi-node HA is supported directly: `control_plane_nodes >= 2` causes kind to auto-spawn an haproxy load-balancer
+container in front of the API servers. Additional knobs: `extra_port_mappings`, `feature_gates`, `runtime_config`, or
+raw `config` YAML override.
+
+#### Context
+
+* `ktor.kind.version`, `ktor.kind.k8s_version`, `ktor.kind.profile`, `ktor.kind.kubeconfig`
+* `ktor.kind.node_image`, `ktor.kind.node_image_registry`
+* `ktor.kind.nodes`, `ktor.kind.control_plane_nodes`, `ktor.kind.provider` (`docker` or `podman`)
+* `ktor.kind.start_fresh`, `ktor.kind.keep_running`
+* `ktor.kind.cmd(*args)` / `ktor.kind.cmd_out(*args)`
+  > Run a `kind` subcommand, optionally capturing output.
 
 ### Terraform Plugin (`terraform`)
 

--- a/src/integrationtest/python/full_smoke/.kubernator.py
+++ b/src/integrationtest/python/full_smoke/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=bool(os.environ["START_FRESH"]),
                          keep_running=bool(os.environ["KEEP_RUNNING"]),
                          profile="full-smoke")

--- a/src/integrationtest/python/helm_latest_version_check/.kubernator.py
+++ b/src/integrationtest/python/helm_latest_version_check/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=True, keep_running=False, profile="helm-latest-version-check")
 ktor.app.register_plugin("k8s")
 ktor.app.register_plugin("helm", version="3.19.0", check_chart_versions=True)

--- a/src/integrationtest/python/issue_17/.kubernator.py
+++ b/src/integrationtest/python/issue_17/.kubernator.py
@@ -5,7 +5,7 @@ phase = int(os.environ["TEST_PHASE"])
 phase1 = (phase == 1)
 phase2 = (phase == 2)
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=phase1, keep_running=phase1, profile="issue-17")
 ktor.app.register_plugin("k8s")
 

--- a/src/integrationtest/python/issue_23/.kubernator.py
+++ b/src/integrationtest/python/issue_23/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=True, keep_running=False, profile="issue-23")
 ktor.app.register_plugin("k8s")
 ktor.app.register_plugin("istio", version=os.environ["ISTIO_VERSION"])

--- a/src/integrationtest/python/issue_35/crd/.kubernator.py
+++ b/src/integrationtest/python/issue_35/crd/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=os.environ["START_FRESH"],
                          keep_running=True, profile="issue-35")
 ktor.app.register_plugin("k8s",

--- a/src/integrationtest/python/issue_35/test/.kubernator.py
+++ b/src/integrationtest/python/issue_35/test/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=False,
                          keep_running=os.environ["KEEP_RUNNING"], profile="issue-35")
 ktor.app.register_plugin("k8s",

--- a/src/integrationtest/python/issue_47/.kubernator.py
+++ b/src/integrationtest/python/issue_47/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=True, keep_running=False, profile="issue-47")
 ktor.app.register_plugin("k8s")
 ktor.app.register_plugin("templates")

--- a/src/integrationtest/python/issue_48/phase1/.kubernator.py
+++ b/src/integrationtest/python/issue_48/phase1/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=True, keep_running=True, profile="issue-48")
 ktor.app.register_plugin("k8s")
 

--- a/src/integrationtest/python/issue_48/phase2/.kubernator.py
+++ b/src/integrationtest/python/issue_48/phase2/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=False, keep_running=False, profile="issue-48")
 ktor.app.register_plugin("k8s")
 

--- a/src/integrationtest/python/issue_52/.kubernator.py
+++ b/src/integrationtest/python/issue_52/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=True, keep_running=False, profile="issue-52")
 ktor.app.register_plugin("k8s")
 ktor.app.register_plugin("istio", version=os.environ["ISTIO_VERSION"])

--- a/src/integrationtest/python/issue_68/.kubernator.py
+++ b/src/integrationtest/python/issue_68/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=bool(os.environ["START_FRESH"]),
                          keep_running=bool(os.environ["KEEP_RUNNING"]),
                          profile="issue-68")

--- a/src/integrationtest/python/issue_72/invalid-oci/.kubernator.py
+++ b/src/integrationtest/python/issue_72/invalid-oci/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=bool(os.environ["START_FRESH"]),
                          keep_running=bool(os.environ["KEEP_RUNNING"]),
                          profile="issue-72")

--- a/src/integrationtest/python/issue_72/invalid-repo/.kubernator.py
+++ b/src/integrationtest/python/issue_72/invalid-repo/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=bool(os.environ["START_FRESH"]),
                          keep_running=bool(os.environ["KEEP_RUNNING"]),
                          profile="issue-72")

--- a/src/integrationtest/python/issue_72/valid/.kubernator.py
+++ b/src/integrationtest/python/issue_72/valid/.kubernator.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import os
 
-ktor.app.register_plugin("minikube", k8s_version=os.environ["K8S_VERSION"],
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
                          start_fresh=bool(os.environ["START_FRESH"]),
                          keep_running=bool(os.environ["KEEP_RUNNING"]),
                          profile="issue-72")

--- a/src/integrationtest/python/minikube_smoke/.kubernator.py
+++ b/src/integrationtest/python/minikube_smoke/.kubernator.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("minikube",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="minikube-smoke",
+                         start_fresh=True,
+                         keep_running=False)
+ktor.app.register_plugin("k8s")

--- a/src/integrationtest/python/minikube_smoke/workload.yaml
+++ b/src/integrationtest/python/minikube_smoke/workload.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pause
+  namespace: default
+  labels:
+    app: pause
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pause
+  template:
+    metadata:
+      labels:
+        app: pause
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10

--- a/src/integrationtest/python/minikube_smoke_tests.py
+++ b/src/integrationtest/python/minikube_smoke_tests.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+import os  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+class MinikubeSmokeTest(IntegrationTestSupport):
+    def test_minikube_smoke(self):
+        test_dir = Path(__file__).parent / "minikube_smoke"
+
+        os.environ["K8S_VERSION"] = self.K8S_TEST_VERSIONS[-1]
+
+        self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "apply", "--yes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/multi_node/.kubernator.py
+++ b/src/integrationtest/python/multi_node/.kubernator.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="multi-node",
+                         nodes=5,
+                         control_plane_nodes=3,
+                         start_fresh=True,
+                         keep_running=False)
+ktor.app.register_plugin("k8s")

--- a/src/integrationtest/python/multi_node/workload.yaml
+++ b/src/integrationtest/python/multi_node/workload.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pause
+  namespace: default
+  labels:
+    app: pause
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pause
+  template:
+    metadata:
+      labels:
+        app: pause
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10

--- a/src/integrationtest/python/multi_node_tests.py
+++ b/src/integrationtest/python/multi_node_tests.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+import json  # noqa: E402
+import os  # noqa: E402
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+class MultiNodeTest(IntegrationTestSupport):
+    def test_multi_node(self):
+        test_dir = Path(__file__).parent / "multi_node"
+
+        os.environ["K8S_VERSION"] = self.K8S_TEST_VERSIONS[-1]
+
+        try:
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "apply", "--yes")
+
+            kubeconfig = Path.home() / ".cache/kubernator/kind/.kube/multi-node/config"
+            self.assertTrue(kubeconfig.exists(),
+                            f"Expected kubeconfig at {kubeconfig}")
+
+            nodes_json = subprocess.check_output(
+                ["docker", "ps", "-a",
+                 "--filter", "label=io.x-k8s.kind.cluster=multi-node",
+                 "--format", "{{.Labels}}"],
+                text=True)
+            roles = [line for line in nodes_json.splitlines() if line]
+            control_planes = [r for r in roles if "io.x-k8s.kind.role=control-plane" in r]
+            workers = [r for r in roles if "io.x-k8s.kind.role=worker" in r]
+            self.assertEqual(len(control_planes), 3,
+                             f"Expected 3 control-plane containers, got {len(control_planes)}: {roles}")
+            self.assertEqual(len(workers), 2,
+                             f"Expected 2 worker containers, got {len(workers)}: {roles}")
+        finally:
+            subprocess.run(["docker", "ps", "-a",
+                            "--filter", "label=io.x-k8s.kind.cluster=multi-node",
+                            "-q"],
+                           check=False)
+            # Best-effort teardown — not strictly required since keep_running=False
+            # already docker-stopped the containers.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/multi_node_tests.py
+++ b/src/integrationtest/python/multi_node_tests.py
@@ -20,7 +20,6 @@ from test_support import IntegrationTestSupport, unittest
 unittest  # noqa
 # Above import must be first
 
-import json  # noqa: E402
 import os  # noqa: E402
 import subprocess  # noqa: E402
 from pathlib import Path  # noqa: E402

--- a/src/main/python/kubernator/plugins/kind.py
+++ b/src/main/python/kubernator/plugins/kind.py
@@ -15,10 +15,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import http.client
 import logging
 import os
+import socket
+import ssl
 import tempfile
+import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 
@@ -328,6 +333,7 @@ class KindPlugin(KubernatorPlugin):
 
     def kind_start(self):
         kind = self.context.kind
+        resumed = False
         if self._cluster_exists(kind.profile):
             stopped = self._cluster_containers(kind.profile, running=False)
             running = self._cluster_containers(kind.profile, running=True)
@@ -335,10 +341,12 @@ class KindPlugin(KubernatorPlugin):
                 logger.info("Starting %d stopped container(s) for kind cluster %r",
                             len(stopped), kind.profile)
                 self._docker("start", *stopped)
+                resumed = True
             elif stopped and running:
                 logger.info("Resuming %d stopped container(s) for kind cluster %r",
                             len(stopped), kind.profile)
                 self._docker("start", *stopped)
+                resumed = True
             else:
                 logger.info("Kind cluster %r is already running", kind.profile)
         else:
@@ -346,8 +354,47 @@ class KindPlugin(KubernatorPlugin):
 
         self._export_kubeconfig()
 
+        # On resume, kind's --wait flag did not run; static pods take a few
+        # seconds to become reachable. Poll /readyz until the apiserver answers
+        # so downstream plugins don't see SSL handshake failures.
+        if resumed:
+            self._wait_for_apiserver()
+
         context = self.context
         context.app.register_plugin("kubectl", version=kind.k8s_version)
+
+    def _wait_for_apiserver(self, timeout=120):
+        with open(self.context.kind.kubeconfig) as f:
+            cfg = yaml.safe_load(f)
+        server_url = cfg["clusters"][0]["cluster"]["server"]
+        parsed = urlparse(server_url)
+        ssl_ctx = ssl._create_unverified_context()
+
+        logger.info("Waiting up to %ds for apiserver at %s to be ready",
+                    timeout, server_url)
+        deadline = time.monotonic() + timeout
+        last_err = None
+        while time.monotonic() < deadline:
+            try:
+                conn = http.client.HTTPSConnection(parsed.hostname, parsed.port,
+                                                   context=ssl_ctx, timeout=5)
+                try:
+                    conn.request("GET", "/readyz")
+                    resp = conn.getresponse()
+                    status = resp.status
+                    resp.read()
+                finally:
+                    conn.close()
+                if status == 200:
+                    logger.info("Apiserver at %s is ready", server_url)
+                    return
+                last_err = f"HTTP {status}"
+            except (OSError, socket.error, ssl.SSLError,
+                    http.client.HTTPException) as e:
+                last_err = f"{type(e).__name__}: {e}"
+            time.sleep(2)
+        raise RuntimeError(
+            f"Apiserver at {server_url} did not become ready within {timeout}s: {last_err}")
 
     def handle_start(self):
         kind = self.context.kind

--- a/src/main/python/kubernator/plugins/kind.py
+++ b/src/main/python/kubernator/plugins/kind.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from kubernator.api import (KubernatorPlugin,
+                            StripNL,
+                            get_golang_os,
+                            get_golang_machine,
+                            prepend_os_path,
+                            get_cache_dir,
+                            CalledProcessError,
+                            )
+
+logger = logging.getLogger("kubernator.kind")
+proc_logger = logger.getChild("proc")
+stdout_logger = StripNL(proc_logger.info)
+stderr_logger = StripNL(proc_logger.warning)
+
+KIND_CLUSTER_LABEL = "io.x-k8s.kind.cluster"
+
+DEFAULT_NODE_IMAGE_REGISTRY = "ghcr.io/karellen/kindest-node"
+
+
+class KindPlugin(KubernatorPlugin):
+    logger = logger
+
+    _name = "kind"
+
+    def __init__(self):
+        self.context = None
+        self.kind_dir = None
+        self.kubeconfig_dir = None
+        self._config_path = None
+        super().__init__()
+
+    def set_context(self, context):
+        self.context = context
+
+    def _resolve_latest_tag(self, repo_url):
+        """Return highest v<major>.<minor>.<patch> tag from a GitHub repo via git ls-remote.
+        Skips pre-release tags like v0.1.0-alpha, v0.2.0-rc.1."""
+        versions = self.context.app.run_capturing_out(
+            ["git", "ls-remote", "-t", "--refs", repo_url, "v*"],
+            stderr_logger,
+        )
+        tuples = []
+        for line in versions.splitlines():
+            if not line:
+                continue
+            # "<sha>\trefs/tags/v1.2.3" -> "1.2.3"
+            tag = line.split()[1][11:]
+            parts = tag.split(".")
+            if len(parts) != 3:
+                continue
+            if not all(p.isdigit() for p in parts):
+                continue
+            tuples.append(tuple(int(p) for p in parts))
+        if not tuples:
+            raise RuntimeError(f"No numeric v<major>.<minor>.<patch> tags found at {repo_url}")
+        return ".".join(str(x) for x in sorted(tuples)[-1])
+
+    def get_latest_kind_version(self):
+        return self._resolve_latest_tag("https://github.com/kubernetes-sigs/kind")
+
+    def cmd(self, *extra_args):
+        stanza, env = self._stanza(list(extra_args))
+        return self.context.app.run(stanza, stdout_logger, stderr_logger, env=env).wait()
+
+    def cmd_out(self, *extra_args):
+        stanza, env = self._stanza(list(extra_args))
+        return self.context.app.run_capturing_out(stanza, stderr_logger, env=env)
+
+    def _stanza(self, extra_args):
+        context = self.context
+        kind = context.kind
+        stanza = [kind.kind_file] + extra_args
+        env = dict(os.environ)
+        env["KUBECONFIG"] = str(kind.kubeconfig)
+        if kind.provider == "podman":
+            env["KIND_EXPERIMENTAL_PROVIDER"] = "podman"
+        return stanza, env
+
+    def _docker_ps(self, *filters, all_containers=True):
+        args = ["docker", "ps", "-q"]
+        if all_containers:
+            args.append("-a")
+        for f in filters:
+            args += ["--filter", f]
+        out = self.context.app.run_capturing_out(args, stderr_logger).strip()
+        return [line for line in out.splitlines() if line]
+
+    def _cluster_containers(self, profile, running=None, all_containers=True):
+        filters = [f"label={KIND_CLUSTER_LABEL}={profile}"]
+        if running is True:
+            filters.append("status=running")
+        elif running is False:
+            filters.append("status=exited")
+        return self._docker_ps(*filters, all_containers=all_containers)
+
+    def _cluster_exists(self, profile):
+        out = self.cmd_out("get", "clusters")
+        return profile in {line.strip() for line in out.splitlines() if line.strip()}
+
+    def _detect_provider(self, provider):
+        context = self.context
+        cmd_debug_logger = StripNL(proc_logger.debug)
+
+        def probe(binary):
+            try:
+                context.app.run([binary, "info"], cmd_debug_logger, cmd_debug_logger).wait()
+                return True
+            except (FileNotFoundError, CalledProcessError) as e:
+                logger.trace("%s is NOT functional", binary, exc_info=e)
+                return False
+
+        if provider:
+            if not probe(provider):
+                raise RuntimeError(f"Requested kind provider {provider!r} is not functional")
+            return provider
+
+        if probe("docker"):
+            logger.info("Docker is functional, selecting 'docker' as the kind provider")
+            return "docker"
+        if probe("podman"):
+            logger.info("Podman is functional, selecting 'podman' as the kind provider")
+            return "podman"
+        raise RuntimeError("No kind provider is functional. Tried 'docker' and 'podman'.")
+
+    def register(self,
+                 kind_version=None,
+                 profile="default",
+                 k8s_version=None,
+                 node_image=None,
+                 node_image_registry=DEFAULT_NODE_IMAGE_REGISTRY,
+                 keep_running=False,
+                 start_fresh=False,
+                 nodes=1,
+                 control_plane_nodes=1,
+                 provider=None,
+                 config=None,
+                 extra_port_mappings=None,
+                 feature_gates=None,
+                 runtime_config=None):
+        context = self.context
+
+        context.app.register_plugin("kubeconfig")
+
+        if not k8s_version and not node_image:
+            msg = "Either k8s_version or node_image must be specified for kind"
+            logger.critical(msg)
+            raise RuntimeError(msg)
+
+        if nodes < 1:
+            raise RuntimeError(f"kind requires nodes >= 1, got {nodes}")
+        if control_plane_nodes < 1:
+            raise RuntimeError(f"kind requires control_plane_nodes >= 1, got {control_plane_nodes}")
+        if control_plane_nodes > nodes:
+            raise RuntimeError(
+                f"control_plane_nodes ({control_plane_nodes}) cannot exceed nodes ({nodes})")
+
+        k8s_version_tuple = tuple(map(int, k8s_version.split("."))) if k8s_version else None
+
+        if not kind_version:
+            kind_version = self.get_latest_kind_version()
+            logger.info("No kind version is specified, latest is %s", kind_version)
+
+        kind_dl_file, _ = context.app.download_remote_file(
+            logger,
+            f"https://github.com/kubernetes-sigs/kind/releases/download/v{kind_version}/"
+            f"kind-{get_golang_os()}-{get_golang_machine()}",
+            "bin",
+        )
+        os.chmod(kind_dl_file, 0o500)
+
+        self.kind_dir = tempfile.TemporaryDirectory()
+        context.app.register_cleanup(self.kind_dir)
+        kind_file = Path(self.kind_dir.name) / "kind"
+        kind_file.symlink_to(kind_dl_file)
+        prepend_os_path(self.kind_dir.name)
+
+        version_out: str = context.app.run_capturing_out(
+            [str(kind_file), "version"], stderr_logger).strip()
+        # "kind v0.31.0 go1.22.1 linux/amd64"
+        version = version_out.split()[1].lstrip("v") if version_out else kind_version
+        logger.info("Found kind %s in %s", version, kind_file)
+
+        profile_dir = get_cache_dir("kind")
+        self.kubeconfig_dir = profile_dir / ".kube" / profile
+        self.kubeconfig_dir.mkdir(parents=True, exist_ok=True)
+        kubeconfig_path = self.kubeconfig_dir / "config"
+
+        resolved_provider = self._detect_provider(provider)
+
+        if not node_image and k8s_version:
+            node_image = f"{node_image_registry}:v{k8s_version}"
+
+        context.globals.kind = dict(
+            version=version,
+            kind_file=str(kind_file),
+            profile=profile,
+            k8s_version=k8s_version,
+            k8s_version_tuple=k8s_version_tuple,
+            node_image=node_image,
+            node_image_registry=node_image_registry,
+            start_fresh=start_fresh,
+            keep_running=keep_running,
+            nodes=nodes,
+            control_plane_nodes=control_plane_nodes,
+            provider=resolved_provider,
+            config=config,
+            extra_port_mappings=list(extra_port_mappings) if extra_port_mappings else [],
+            feature_gates=dict(feature_gates) if feature_gates else {},
+            runtime_config=dict(runtime_config) if runtime_config else {},
+            kubeconfig=str(kubeconfig_path),
+            cmd=self.cmd,
+            cmd_out=self.cmd_out,
+        )
+        context.kubeconfig.kubeconfig = context.kind.kubeconfig
+
+        logger.info("Kind kubeconfig is %s", context.kind.kubeconfig)
+        logger.info("Kind node image is %s", node_image)
+
+    def _generate_cluster_config(self):
+        kind = self.context.kind
+        if kind.config:
+            return kind.config
+
+        needs_config = (kind.nodes > 1
+                        or kind.control_plane_nodes > 1
+                        or kind.extra_port_mappings
+                        or kind.feature_gates
+                        or kind.runtime_config)
+        if not needs_config:
+            return None
+
+        doc = {
+            "kind": "Cluster",
+            "apiVersion": "kind.x-k8s.io/v1alpha4",
+        }
+        if kind.feature_gates:
+            doc["featureGates"] = {k: bool(v) for k, v in kind.feature_gates.items()}
+        if kind.runtime_config:
+            doc["runtimeConfig"] = {k: str(v) for k, v in kind.runtime_config.items()}
+
+        node_list = []
+        for i in range(kind.control_plane_nodes):
+            entry = {"role": "control-plane"}
+            if i == 0 and kind.extra_port_mappings:
+                entry["extraPortMappings"] = [dict(m) for m in kind.extra_port_mappings]
+            node_list.append(entry)
+        for _ in range(kind.nodes - kind.control_plane_nodes):
+            node_list.append({"role": "worker"})
+        doc["nodes"] = node_list
+
+        return yaml.safe_dump(doc, sort_keys=False)
+
+    def _write_cluster_config(self):
+        config_yaml = self._generate_cluster_config()
+        if not config_yaml:
+            self._config_path = None
+            return None
+        self._config_path = Path(self.kind_dir.name) / "cluster.yaml"
+        self._config_path.write_text(config_yaml)
+        logger.debug("Wrote kind cluster config to %s:\n%s", self._config_path, config_yaml)
+        return self._config_path
+
+    def _export_kubeconfig(self):
+        kind = self.context.kind
+        self.cmd("export", "kubeconfig",
+                 "--name", kind.profile,
+                 "--kubeconfig", str(kind.kubeconfig))
+        logger.info("Exported kubeconfig for cluster %r to %s", kind.profile, kind.kubeconfig)
+
+    def _docker(self, *args, capture=False):
+        cmd_args = ["docker", *args]
+        if capture:
+            return self.context.app.run_capturing_out(cmd_args, stderr_logger)
+        return self.context.app.run(cmd_args, stdout_logger, stderr_logger).wait()
+
+    def kind_create(self):
+        kind = self.context.kind
+        args = ["create", "cluster", "--name", kind.profile, "--wait", "120s"]
+        if kind.node_image:
+            args += ["--image", kind.node_image]
+        config_path = self._write_cluster_config()
+        if config_path:
+            args += ["--config", str(config_path)]
+        logger.info("Creating kind cluster %r (image=%s, nodes=%d, control_plane_nodes=%d)",
+                    kind.profile, kind.node_image, kind.nodes, kind.control_plane_nodes)
+        self.cmd(*args)
+
+    def kind_delete(self):
+        kind = self.context.kind
+        logger.warning("Deleting kind cluster %r", kind.profile)
+        try:
+            self.cmd("delete", "cluster", "--name", kind.profile)
+        except CalledProcessError as e:
+            logger.warning("kind delete failed for %r: %s", kind.profile, e)
+
+    def kind_stop(self):
+        kind = self.context.kind
+        running = self._cluster_containers(kind.profile, running=True)
+        if not running:
+            logger.info("Kind cluster %r has no running containers", kind.profile)
+            return
+        logger.info("Stopping %d container(s) for kind cluster %r", len(running), kind.profile)
+        self._docker("stop", *running)
+
+    def kind_start(self):
+        kind = self.context.kind
+        if self._cluster_exists(kind.profile):
+            stopped = self._cluster_containers(kind.profile, running=False)
+            running = self._cluster_containers(kind.profile, running=True)
+            if stopped and not running:
+                logger.info("Starting %d stopped container(s) for kind cluster %r",
+                            len(stopped), kind.profile)
+                self._docker("start", *stopped)
+            elif stopped and running:
+                logger.info("Resuming %d stopped container(s) for kind cluster %r",
+                            len(stopped), kind.profile)
+                self._docker("start", *stopped)
+            else:
+                logger.info("Kind cluster %r is already running", kind.profile)
+        else:
+            self.kind_create()
+
+        self._export_kubeconfig()
+
+        context = self.context
+        context.app.register_plugin("kubectl", version=kind.k8s_version)
+
+    def handle_start(self):
+        kind = self.context.kind
+        if kind.start_fresh:
+            if self._cluster_exists(kind.profile):
+                self.kind_delete()
+        self.kind_start()
+
+    def handle_shutdown(self):
+        kind = self.context.kind
+        if kind.keep_running:
+            logger.warning("Keeping kind cluster %r running", kind.profile)
+            return
+        self.kind_stop()
+
+    def __repr__(self):
+        return "Kind Plugin"


### PR DESCRIPTION
## Summary

Introduces a `kind` (Kubernetes IN Docker) plugin as a faster-inner-loop alternative to the existing `minikube` plugin, and migrates all 14 internal integration tests from minikube to kind. `MinikubePlugin` is retained unchanged as a supported plugin for external users and keeps CI signal through a dedicated `minikube_smoke/` test.

### `KindPlugin`

- Wraps the `kind` binary (downloaded on demand, same pattern as `MinikubePlugin`).
- Defaults node images to `ghcr.io/karellen/kindest-node:v<k8s_version>` — pre-built for every upstream K8s release ≥ 1.29.0 by the `kindest-node-release` workflow (#99).
- Multi-node + HA via `nodes` / `control_plane_nodes` kwargs; `control_plane_nodes >= 2` triggers kind's automatic haproxy LB container in front of the API servers.
- Lifecycle maps minikube's `start`/`stop`/`delete` semantics onto kind's `create`/`delete` CLI plus `docker stop`/`docker start` on labeled node containers (`label=io.x-k8s.kind.cluster=<profile>`). `keep_running=False` stops without deleting so the next run resumes with state intact; `start_fresh=True` deletes and recreates.
- Provider auto-detects `docker` then `podman` (`KIND_EXPERIMENTAL_PROVIDER=podman`).
- Additional knobs: `node_image`, `node_image_registry`, `extra_port_mappings`, `feature_gates`, `runtime_config`, raw `config` YAML override.

### Intentional non-scope

The plugin does **not** install CSI hostpath, external-snapshotter, or cloud-provider-kind. Those are separate `kubernetes-sigs` projects, not part of kind itself. Users who need them install them explicitly in their own `.kubernator.py`, same as they would on any upstream cluster. This is the key shape difference from `MinikubePlugin`, which wraps minikube's bundled addon system — on kind there is no addon system to wrap.

### Integration test changes

- New `src/integrationtest/python/multi_node/` — exercises HA 3 control-plane + 2 worker topology; also validates the labeled-container discovery used for lifecycle.
- New `src/integrationtest/python/minikube_smoke/` — preserves CI signal for `MinikubePlugin` after the wholesale sweep.
- Every existing `register_plugin("minikube", …)` call swept to `register_plugin("kind", …)` across `full_smoke`, `issue_17`, `issue_23`, `issue_35/{crd,test}`, `issue_47`, `issue_48/{phase1,phase2}`, `issue_52`, `issue_68`, `issue_72/{valid,invalid-oci,invalid-repo}`, `helm_latest_version_check`. The kwargs `profile`, `k8s_version`, `start_fresh`, `keep_running` have identical semantics on both plugins so no other changes were needed.

### Docs

- Project `CLAUDE.md` plugin list updated.
- `README.md` gets a `Kind Plugin` section and a row in the plugin table.

## Test plan

- [x] `KindPlugin` imports cleanly and registers under `kind` in the plugin discovery
- [x] Smoke-test plugin against a fresh single-node cluster (create, kubeconfig export, shutdown via `docker stop`)
- [x] Smoke-test resume path: `start_fresh=False` on an existing stopped cluster correctly `docker start`s the node containers
- [x] Smoke-test `start_fresh=True` delete-and-recreate path
- [x] `multi_node/` test: HA 3 CP + 2 worker cluster boots, applies a trivial Deployment, asserts container counts via Docker labels, cleanly shuts down. Passing locally in ~73s.
- [x] `minikube_smoke/` test: passes locally in ~78s
- [ ] Full pyb integration suite against the 7 K8s versions in `K8S_TEST_VERSIONS` (1.29.15 — 1.35.3) — pending CI