### PR TITLE
Refactor k8s apply: SSA test-ops, 409 retry, watch-based delete, imperative API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,10 @@ PyBuilder project — standard `src/main/python`, `src/unittest/python`,
 
 ## Build / Test
 
-PyBuilder per global instructions. Key bits specific to this repo:
+PyBuilder per global instructions. Always use `pyb -vX` (verbose + debug output) for
+all build invocations, including subset tasks (e.g. `pyb -vX run_unit_tests`).
+
+Key bits specific to this repo:
 
 - `coverage_break_build = False` and `cram_fail_if_no_tests = False` — build does not
   fail on coverage thresholds or empty cram dirs. Do not assume failures surface there.

--- a/README.md
+++ b/README.md
@@ -458,6 +458,11 @@ File discovery uses globs `*.yaml` / `*.yml` by default, configurable per-direct
 * `ktor.k8s.add_manifest_patcher(func)` — register a low-level manifest patcher.
 * `ktor.k8s.get_api_versions()` — set of `(group, version)` tuples in use.
 * `ktor.k8s.create_resource(manifest)` — wrap a manifest as a `K8SResource` without registering it.
+* `ktor.k8s.resource(manifest)` — return a fully-wired `K8SResource` with API bindings populated, for
+  imperative CRUD (`.get()`, `.create(dry_run=False)`, `.patch(...)`, `.delete(wait=True)`, `.watch()`)
+  that bypasses the declarative apply lifecycle. Accepts a manifest `dict` or a single-document YAML string.
+* `ktor.k8s.resource_generator()` — iterable of resources fed to the apply pipeline; override this on
+  a subclass / wrap via context binding to filter or augment the set declaratively before apply.
 * `ktor.k8s.client`, `ktor.k8s.server_version`, `ktor.k8s.server_git_version` — access the underlying Kubernetes client.
 * `ktor.k8s.field_validation` (`"Ignore"`/`"Warn"`/`"Strict"`),
   `ktor.k8s.field_validation_warn_fatal`,

--- a/src/integrationtest/python/delete_create/.kubernator.py
+++ b/src/integrationtest/python/delete_create/.kubernator.py
@@ -1,0 +1,43 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="delete-create",
+                         start_fresh=True,
+                         keep_running=False)
+ktor.app.register_plugin("k8s")
+
+ktor.k8s.resource("""
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl:5.34.0
+        command: ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
+""").create(dry_run=False)
+
+ktor.k8s.add_resources("""
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl:5.34.0
+        command: ["perl", "-Mbignum=bpi", "-wle", "print 0"]
+      restartPolicy: Never
+  backoffLimit: 4
+""")

--- a/src/integrationtest/python/delete_create_tests.py
+++ b/src/integrationtest/python/delete_create_tests.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+import os  # noqa: E402
+
+
+class DeleteCreateTest(IntegrationTestSupport):
+    def test_delete_create(self):
+        test_dir = Path(__file__).parent / "delete_create"
+
+        for k8s_version in (self.K8S_TEST_VERSIONS[-1],):
+            os.environ["K8S_VERSION"] = k8s_version
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "apply", "--yes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/resource_generator/.kubernator.py
+++ b/src/integrationtest/python/resource_generator/.kubernator.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="resource-generator",
+                         start_fresh=True,
+                         keep_running=True)
+ktor.app.register_plugin("k8s")
+
+_original_gen = ktor.k8s.resource_generator
+
+
+def _filtered_gen():
+    for resource in _original_gen():
+        if resource.name != "cm-skip":
+            yield resource
+
+
+ktor.k8s.resource_generator = _filtered_gen

--- a/src/integrationtest/python/resource_generator/cm-keep.yaml
+++ b/src/integrationtest/python/resource_generator/cm-keep.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-keep
+  namespace: default
+data:
+  kind: keep

--- a/src/integrationtest/python/resource_generator/cm-skip.yaml
+++ b/src/integrationtest/python/resource_generator/cm-skip.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-skip
+  namespace: default
+data:
+  kind: skip

--- a/src/integrationtest/python/resource_generator_tests.py
+++ b/src/integrationtest/python/resource_generator_tests.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+import os  # noqa: E402
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+class ResourceGeneratorSeamTest(IntegrationTestSupport):
+    def test_custom_generator_filters_apply_set(self):
+        test_dir = Path(__file__).parent / "resource_generator"
+        os.environ["K8S_VERSION"] = self.K8S_TEST_VERSIONS[-1]
+
+        try:
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "apply", "--yes")
+
+            kubeconfig = Path.home() / ".cache/kubernator/kind/.kube/resource-generator/config"
+            self.assertTrue(kubeconfig.exists(), f"Expected kubeconfig at {kubeconfig}")
+            env = {**os.environ, "KUBECONFIG": str(kubeconfig)}
+
+            out = subprocess.check_output(
+                ["kubectl", "get", "cm", "-n", "default", "-o", "name"],
+                env=env, text=True)
+
+            self.assertIn("configmap/cm-keep", out,
+                          f"cm-keep (yielded by custom generator) should have been applied; got {out!r}")
+            self.assertNotIn("configmap/cm-skip", out,
+                             f"cm-skip (filtered out by custom generator) should not have been applied; got {out!r}")
+        finally:
+            ids = subprocess.check_output(
+                ["docker", "ps", "-aq",
+                 "--filter", "label=io.x-k8s.kind.cluster=resource-generator"],
+                text=True).split()
+            if ids:
+                subprocess.run(["docker", "rm", "-f"] + ids, check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/resource_version_merge/.kubernator.py
+++ b/src/integrationtest/python/resource_version_merge/.kubernator.py
@@ -1,0 +1,29 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="resource-version-merge",
+                         start_fresh=True,
+                         keep_running=False)
+ktor.app.register_plugin("k8s")
+
+ktor.k8s.resource("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+data:
+  a: b
+""").create(dry_run=False)
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default
+data:
+  a: c
+""")

--- a/src/integrationtest/python/resource_version_merge_tests.py
+++ b/src/integrationtest/python/resource_version_merge_tests.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2023 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+import json
+import tempfile
+
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+import os  # noqa: E402
+
+
+class ResourceVersionMergeTest(IntegrationTestSupport):
+    def test_resource_version_merge(self):
+        test_dir = Path(__file__).parent / "resource_version_merge"
+
+        for k8s_version in (self.K8S_TEST_VERSIONS[-1],):
+            os.environ["K8S_VERSION"] = k8s_version
+
+            tmp_file_name = tempfile.mktemp()
+            try:
+                self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE",
+                                     "-o", "json",
+                                     "-f", tmp_file_name)
+                with open(tmp_file_name, "r") as f:
+                    result = json.load(f)
+
+                test_ops_found = 0
+                self.assertEqual(len(result), 1)
+                for op in result[0]["body"]:
+                    if op["op"] == "test":
+                        test_ops_found += 1
+                        self.assertTrue(op["path"] in ("/metadata/uid", "/metadata/resourceVersion"))
+                    else:
+                        self.assertEqual(op["op"], "replace")
+                        self.assertEqual(op["path"], "/data/a")
+                        self.assertEqual(op["value"], "c")
+
+                self.assertEqual(test_ops_found, 2)
+            finally:
+                os.unlink(tmp_file_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/watch_resource/.kubernator.py
+++ b/src/integrationtest/python/watch_resource/.kubernator.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="watch-resource",
+                         start_fresh=True,
+                         keep_running=True)
+ktor.app.register_plugin("k8s")

--- a/src/integrationtest/python/watch_resource/configmap.yaml
+++ b/src/integrationtest/python/watch_resource/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: watch-target
+  namespace: default
+data:
+  key1: value1
+  key2: value2

--- a/src/integrationtest/python/watch_tests.py
+++ b/src/integrationtest/python/watch_tests.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+import os  # noqa: E402
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+class WatchTest(IntegrationTestSupport):
+    def test_watch_yields_event_for_existing_resource(self):
+        test_dir = Path(__file__).parent / "watch_resource"
+        os.environ["K8S_VERSION"] = self.K8S_TEST_VERSIONS[-1]
+
+        try:
+            self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "apply", "--yes")
+
+            from kubernetes import client, config
+            from kubernator.plugins.k8s_api import (K8SResource, K8SResourceDef, K8SResourceDefKey)
+
+            kubeconfig = Path.home() / ".cache/kubernator/kind/.kube/watch-resource/config"
+            self.assertTrue(kubeconfig.exists(), f"Expected kubeconfig at {kubeconfig}")
+
+            config.load_kube_config(config_file=str(kubeconfig))
+            api_client = client.ApiClient()
+
+            rdef = K8SResourceDef(K8SResourceDefKey("", "v1", "ConfigMap"),
+                                  "configmap", "configmaps", True, False, None)
+            rdef.populate_api(client, api_client)
+
+            manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                        "metadata": {"name": "watch-target", "namespace": "default"}}
+            resource = K8SResource(manifest, rdef, source="watch_test")
+
+            events = list(resource.watch(timeout_seconds=5))
+
+            matching = []
+            for ev in events:
+                obj = ev["object"]
+                name = obj["metadata"]["name"] if isinstance(obj, dict) else obj.metadata.name
+                if name == "watch-target":
+                    matching.append(ev)
+
+            self.assertGreaterEqual(len(matching), 1,
+                                    f"Expected watch to yield at least one event for watch-target; got {events}")
+        finally:
+            ids = subprocess.check_output(
+                ["docker", "ps", "-aq",
+                 "--filter", "label=io.x-k8s.kind.cluster=watch-resource"],
+                text=True).split()
+            if ids:
+                subprocess.run(["docker", "rm", "-f"] + ids, check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/kubernator/app.py
+++ b/src/main/python/kubernator/app.py
@@ -535,26 +535,21 @@ def main():
     else:
         log_stream = sys.stderr
 
-    if args.file:
-        args.file = open(args.file, "w")
-    else:
-        args.file = sys.stdout
-
     init_logging(args.verbose, args.log_format, log_stream)
 
     try:
         if args.clear_cache:
             clear_cache()
-            return
+            return 0
 
         if args.clear_k8s_cache:
             clear_k8s_cache()
-            return
+            return 0
 
         if args.pre_cache_k8s_client:
             pre_cache_k8s_clients(*args.pre_cache_k8s_client,
                                   disable_patching=args.pre_cache_k8s_client_no_patch)
-            return
+            return 0
 
         with App(args) as app:
             app.run()
@@ -571,7 +566,4 @@ def main():
         finally:
             if log_stream != sys.stderr:
                 with closing(log_stream):
-                    pass
-            if args.file != sys.stdout:
-                with closing(args.file):
                     pass

--- a/src/main/python/kubernator/plugins/istio.py
+++ b/src/main/python/kubernator/plugins/istio.py
@@ -35,7 +35,7 @@ from kubernator.api import (KubernatorPlugin, scan_dir,
                             get_golang_os,
                             get_golang_machine,
                             prepend_os_path, jp, load_file)
-from kubernator.plugins.k8s import api_exc_normalize_body, api_exc_format_body
+from kubernator.plugins.k8s_api import api_exc_format_body
 from kubernator.plugins.k8s_api import K8SResourcePluginMixin
 
 logger = logging.getLogger("kubernator.istio")
@@ -279,16 +279,10 @@ class IstioPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         try:
             res.delete(dry_run=dry_run)
         except ApiException as e:
-            api_exc_normalize_body(e)
-            try:
-                skip = False
-                if e.status == 404 and missing_ok:
-                    skip = True
-                if not skip:
-                    raise
-            except ApiException as e:
-                api_exc_format_body(e)
-                raise
+            if e.status == 404 and missing_ok:
+                return res
+            api_exc_format_body(e)
+            raise
 
         return res
 
@@ -304,18 +298,10 @@ class IstioPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         try:
             res.create(dry_run=dry_run)
         except ApiException as e:
-            skip = False
-            api_exc_normalize_body(e)
-            try:
-                if e.status == 409:
-                    status = e.body
-                    if status["reason"] == "AlreadyExists" and exists_ok:
-                        skip = True
-                if not skip:
-                    raise
-            except ApiException as e:
-                api_exc_format_body(e)
-                raise
+            if e.status == 409 and e.body.get("reason") == "AlreadyExists" and exists_ok:
+                return res
+            api_exc_format_body(e)
+            raise
 
         return res
 

--- a/src/main/python/kubernator/plugins/k8s.py
+++ b/src/main/python/kubernator/plugins/k8s.py
@@ -26,11 +26,10 @@ from collections.abc import Mapping
 from functools import partial
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Iterable, Callable, Sequence
+from typing import Iterable, Callable, Sequence, Optional
 
 import jsonpatch
 import yaml
-from kubernetes.client import ApiException
 
 from kubernator.api import (KubernatorPlugin,
                             Globs,
@@ -41,12 +40,14 @@ from kubernator.api import (KubernatorPlugin,
                             StripNL,
                             install_python_k8s_client,
                             TemplateEngine,
-                            sleep)
+                            calling_frame_source,
+                            parse_yaml_docs)
 from kubernator.merge import extract_merge_instructions, apply_merge_instructions
 from kubernator.plugins.k8s_api import (K8SResourcePluginMixin,
                                         K8SResource,
                                         K8SResourcePatchType,
-                                        K8SPropagationPolicy)
+                                        K8SPropagationPolicy,
+                                        api_exc_format_body)
 
 logger = logging.getLogger("kubernator.k8s")
 proc_logger = logger.getChild("proc")
@@ -82,21 +83,6 @@ def normalize_pkg_version(v: str):
             new_rev += c
         v_split[-1] = new_rev
     return tuple(map(int, v_split))
-
-
-def api_exc_normalize_body(e: "ApiException"):
-    if e.headers and "content-type" in e.headers:
-        content_type = e.headers["content-type"]
-        if content_type == "application/json" or content_type.endswith("+json"):
-            e.body = json.loads(e.body)
-        elif (content_type in ("application/yaml", "application/x-yaml", "text/yaml",
-                               "text/x-yaml") or content_type.endswith("+yaml")):
-            e.body = yaml.safe_load(e.body)
-
-
-def api_exc_format_body(e: ApiException):
-    if not isinstance(e.body, (str, bytes)):
-        e.body = json.dumps(e.body, indent=4)
 
 
 class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
@@ -159,6 +145,8 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                    field_validation=field_validation,
                                    field_validation_warn_fatal=field_validation_warn_fatal,
                                    field_validation_warnings=0,
+                                   resource_generator=self.resource_generator,
+                                   resource=self.resource,
                                    conflict_retry_delay=0.3,
                                    _k8s=self,
                                    )
@@ -273,6 +261,22 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                 if manifest:
                     self.add_resource(manifest, display_p)
 
+    def resource_generator(self):
+        yield from self.resources.values()
+
+    def resource(self, manifest, source=None):
+        from kubernetes import client
+        if not source:
+            source = calling_frame_source()
+        if isinstance(manifest, str):
+            docs = [m for m in parse_yaml_docs(manifest, source) if m]
+            if len(docs) != 1:
+                raise ValueError(f"ktor.k8s.resource() expects a single manifest document, got {len(docs)} from {source}")
+            manifest = docs[0]
+        res = self._create_resource(manifest, source)
+        res.rdef.populate_api(client, self.context.k8s.client)
+        return res
+
     def handle_apply(self):
         context = self.context
         k8s = context.k8s
@@ -280,19 +284,19 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         self._validate_resources()
 
         cmd = context.app.args.command
-        file = context.app.args.file
+        file_name = context.app.args.file
         file_format = context.app.args.output_format
         dry_run = context.app.args.dry_run
         dump = cmd == "dump"
 
         status_msg = f"{' (dump only)' if dump else ' (dry run)' if dry_run else ''}"
         if dump:
-            logger.info("Will dump the changes into a file %s in %s format", file, file_format)
+            logger.info("Will dump the changes into a file %s in %s format", file_name or "<stdout>", file_format)
 
         patch_field_excludes = [re.compile(e) for e in context.globals.k8s.patch_field_excludes]
         dump_results = []
         total_created, total_patched, total_deleted = 0, 0, 0
-        for resource in self.resources.values():
+        for resource in k8s.resource_generator():
             if dump:
                 resource_id = {"apiVersion": resource.api_version,
                                "kind": resource.kind,
@@ -307,11 +311,13 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                          "body": patch
                                          }
                     dump_results.append(method_descriptor)
+                    return resource.manifest
 
                 def create_func():
                     method_descriptor = {"method": "create",
                                          "body": resource.manifest}
                     dump_results.append(method_descriptor)
+                    return resource.manifest
 
                 def delete_func(*, propagation_policy):
                     method_descriptor = {"method": "delete",
@@ -319,18 +325,19 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                          "propagation_policy": propagation_policy.policy
                                          }
                     dump_results.append(method_descriptor)
+                    return None
             else:
                 patch_func = partial(resource.patch, patch_type=K8SResourcePatchType.JSON_PATCH, dry_run=dry_run)
                 create_func = partial(resource.create, dry_run=dry_run)
                 delete_func = partial(resource.delete, dry_run=dry_run)
 
-            created, patched, deleted = self._apply_resource(dry_run,
-                                                             patch_field_excludes,
-                                                             resource,
-                                                             patch_func,
-                                                             create_func,
-                                                             delete_func,
-                                                             status_msg)
+            created, patched, deleted, result = self._apply_resource(dry_run,
+                                                                     patch_field_excludes,
+                                                                     resource,
+                                                                     patch_func,
+                                                                     create_func,
+                                                                     delete_func,
+                                                                     status_msg)
 
             total_created += created
             total_patched += patched
@@ -344,11 +351,16 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
             raise RuntimeError(msg)
 
         if dump:
-            if file_format in ("json", "json-pretty"):
-                json.dump(dump_results, file, sort_keys=True,
-                          indent=4 if file_format == "json-pretty" else None)
-            else:
-                yaml.safe_dump(dump_results, file)
+            file = open(file_name, "w") if file_name else sys.stdout
+            try:
+                if file_format in ("json", "json-pretty"):
+                    json.dump(dump_results, file, sort_keys=True,
+                              indent=4 if file_format == "json-pretty" else None)
+                else:
+                    yaml.safe_dump(dump_results, file)
+            finally:
+                if file_name:
+                    file.close()
         else:
             self._summary = total_created, total_patched, total_deleted
 
@@ -449,8 +461,8 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                         dry_run,
                         patch_field_excludes: Iterable[re.compile],
                         resource: K8SResource,
-                        patch_func: Callable[[Iterable[dict]], None],
-                        create_func: Callable[[], None],
+                        patch_func: Callable[[Iterable[dict]], Optional[dict]],
+                        create_func: Callable[[], Optional[dict]],
                         delete_func: Callable[[K8SPropagationPolicy], None],
                         status_msg):
         from kubernetes import client
@@ -477,31 +489,15 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                      resource, resource.source, status["message"])
                         raise e from None
 
-        def create(exists_ok=False, wait_for_delete=False):
+        def create(exists_ok=False):
             logger.info("Creating resource %s%s%s", resource, status_msg,
                         " (ignoring existing)" if exists_ok else "")
-            while True:
-                try:
-                    create_func()
-                    return
-                except ApiException as __e:
-                    api_exc_normalize_body(__e)
-                    try:
-                        if exists_ok or wait_for_delete:
-                            if __e.status == 409:
-                                status = __e.body
-                                if status["reason"] == "AlreadyExists":
-                                    if wait_for_delete:
-                                        sleep(self.context.k8s.conflict_retry_delay)
-                                        logger.info("Retry creating resource %s%s%s", resource, status_msg,
-                                                    " (ignoring existing)" if exists_ok else "")
-                                        continue
-                                    else:
-                                        return
-                        raise
-                    except ApiException as ___e:
-                        api_exc_format_body(___e)
-                        raise
+            try:
+                return create_func()
+            except ApiException as __e:
+                if exists_ok and __e.status == 409 and __e.body["reason"] == "AlreadyExists":
+                    return None
+                raise
 
         merge_instrs, normalized_manifest = extract_merge_instructions(resource.manifest, resource)
         if merge_instrs:
@@ -515,14 +511,11 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
             remote_resource = resource.get()
             logger.trace("Current resource %s: %s", resource, remote_resource)
         except ApiException as e:
-            api_exc_normalize_body(e)
             try:
                 if e.status == 404:
                     try:
-                        create()
-                        return 1, 0, 0
+                        return 1, 0, 0, create()
                     except ApiException as e:
-                        api_exc_normalize_body(e)
                         if not handle_400_strict_validation_error(e):
                             raise
                 else:
@@ -531,80 +524,94 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                 api_exc_format_body(_e)
                 raise
         else:
-            logger.trace("Attempting to retrieve a normalized patch for resource %s: %s", resource, normalized_manifest)
-            try:
-                merged_resource = resource.patch(normalized_manifest,
-                                                 patch_type=K8SResourcePatchType.SERVER_SIDE_PATCH,
-                                                 dry_run=True,
-                                                 force=True)
-            except ApiException as e:
+            while True:
+                logger.trace("Attempting to retrieve a normalized patch for resource %s: %s",
+                             resource, normalized_manifest)
                 try:
-                    api_exc_normalize_body(e)
+                    merged_resource = resource.patch(normalized_manifest,
+                                                     patch_type=K8SResourcePatchType.SERVER_SIDE_PATCH,
+                                                     dry_run=True,
+                                                     force=True)
+                except ApiException as e:
+                    try:
+                        if e.status == 422:
+                            status = e.body
+                            # Assumes the body has been unmarshalled
+                            details = status["details"]
+                            immutable_key = details.get("group"), details["kind"]
 
-                    if e.status == 422:
-                        status = e.body
-                        # Assumes the body has been unmarshalled
-                        details = status["details"]
-                        immutable_key = details.get("group"), details["kind"]
-
-                        try:
-                            propagation_policy = self.context.k8s.immutable_changes[immutable_key]
-                        except KeyError:
-                            raise e from None
+                            try:
+                                propagation_policy = self.context.k8s.immutable_changes[immutable_key]
+                            except KeyError:
+                                raise e from None
+                            else:
+                                for cause in details["causes"]:
+                                    if (
+                                            cause["reason"] == "FieldValueInvalid" and
+                                            "field is immutable" in cause["message"]
+                                            or
+                                            cause["reason"] == "FieldValueForbidden" and
+                                            ("Forbidden: updates to" in cause["message"]
+                                             or
+                                             "Forbidden: pod updates" in cause["message"])
+                                    ):
+                                        logger.info("Deleting resource %s (cascade %s)%s", resource,
+                                                    propagation_policy.policy,
+                                                    status_msg)
+                                        delete_func(propagation_policy=propagation_policy)
+                                        return 1, 0, 1, create(exists_ok=dry_run)
+                                raise
                         else:
-                            for cause in details["causes"]:
-                                if (
-                                        cause["reason"] == "FieldValueInvalid" and
-                                        "field is immutable" in cause["message"]
-                                        or
-                                        cause["reason"] == "FieldValueForbidden" and
-                                        ("Forbidden: updates to" in cause["message"]
-                                         or
-                                         "Forbidden: pod updates" in cause["message"])
-                                ):
-                                    logger.info("Deleting resource %s (cascade %s)%s", resource,
-                                                propagation_policy.policy,
-                                                status_msg)
-                                    delete_func(propagation_policy=propagation_policy)
-                                    create(exists_ok=dry_run, wait_for_delete=not dry_run)
-                                    return 1, 0, 1
+                            if not handle_400_strict_validation_error(e):
+                                raise
+                    except ApiException as _e:
+                        api_exc_format_body(_e)
+                        raise
+
+                else:
+                    logger.trace("Merged resource %s: %s", resource, merged_resource)
+                    if merge_instrs:
+                        apply_merge_instructions(merge_instrs, normalized_manifest, merged_resource, logger, resource)
+
+                    patch = jsonpatch.make_patch(remote_resource, merged_resource)
+
+                    resource_version = merged_resource["metadata"]["resourceVersion"]
+                    resource_uid = merged_resource["metadata"]["uid"]
+                    logger.trace("Resource %s adding resourceVersion %s and UID %s tests", resource, resource_version,
+                                 resource_uid)
+                    patch.patch.append({"op": "test", "path": "/metadata/uid", "value": resource_uid})
+                    patch.patch.append({"op": "test", "path": "/metadata/resourceVersion", "value": resource_version})
+
+                    logger.trace("Resource %s initial patches are: %s", resource, patch)
+                    patch = self._filter_resource_patch(patch, patch_field_excludes)
+                    logger.trace("Resource %s final patches are: %s", resource, patch)
+                    if patch:
+                        logger.info("Patching resource %s%s", resource, status_msg)
+                        try:
+                            return 0, 1, 0, patch_func(patch)
+                        except ApiException as e:
+                            if e.status == 409:
+                                logger.warning("Patching resource %s%s encountered a conflict - will retry: \n%s",
+                                               resource, status_msg, yaml.dump(e.body))
+                                continue
                             raise
                     else:
-                        if not handle_400_strict_validation_error(e):
-                            raise
-                except ApiException as _e:
-                    api_exc_format_body(_e)
-                    raise
-
-            else:
-                logger.trace("Merged resource %s: %s", resource, merged_resource)
-                if merge_instrs:
-                    apply_merge_instructions(merge_instrs, normalized_manifest, merged_resource, logger, resource)
-
-                patch = jsonpatch.make_patch(remote_resource, merged_resource)
-                logger.trace("Resource %s initial patches are: %s", resource, patch)
-                patch = self._filter_resource_patch(patch, patch_field_excludes)
-                logger.trace("Resource %s final patches are: %s", resource, patch)
-                if patch:
-                    logger.info("Patching resource %s%s", resource, status_msg)
-                    patch_func(patch)
-                    return 0, 1, 0
-                else:
-                    logger.info("Nothing to patch for resource %s", resource)
-                    return 0, 0, 0
+                        logger.info("Nothing to patch for resource %s", resource)
+                        return 0, 0, 0, None
 
     def _filter_resource_patch(self, patch: Iterable[Mapping], excludes: Iterable[re.compile]):
         result = []
         for op in patch:
-            path = op["path"]
-            excluded = False
-            for exclude in excludes:
-                if exclude.match(path):
-                    logger.trace("Excluding %r from patch %s", op, patch)
-                    excluded = True
-                    break
-            if excluded:
-                continue
+            if op["op"] != "test":
+                path = op["path"]
+                excluded = False
+                for exclude in excludes:
+                    if exclude.match(path):
+                        logger.trace("Excluding %r from patch %s", op, patch)
+                        excluded = True
+                        break
+                if excluded:
+                    continue
             result.append(op)
         return result
 

--- a/src/main/python/kubernator/plugins/k8s_api.py
+++ b/src/main/python/kubernator/plugins/k8s_api.py
@@ -22,7 +22,7 @@ import re
 from collections import namedtuple
 from collections.abc import Callable, Mapping, MutableMapping, Sequence, Iterable
 from enum import Enum, auto
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 from typing import Union, Optional
 
@@ -34,6 +34,45 @@ from jsonschema.validators import extend, Draft7Validator
 from openapi_schema_validator import OAS31Validator
 
 from kubernator.api import load_file, FileType, load_remote_file, calling_frame_source, parse_yaml_docs
+
+
+def api_exc_normalize_body(e):
+    """Parse a raw ApiException body (JSON or YAML) into a Python object in-place.
+
+    Idempotent: if e.body is already a parsed object, it is left unchanged.
+    """
+    if not isinstance(e.body, (str, bytes)):
+        return
+    if e.headers and "content-type" in e.headers:
+        content_type = e.headers["content-type"]
+        if content_type == "application/json" or content_type.endswith("+json"):
+            e.body = json.loads(e.body)
+        elif (content_type in ("application/yaml", "application/x-yaml", "text/yaml",
+                               "text/x-yaml") or content_type.endswith("+yaml")):
+            e.body = yaml.safe_load(e.body)
+
+
+def api_exc_format_body(e):
+    """Format an ApiException body back to a string for human-readable display.
+
+    Idempotent: if e.body is already a string/bytes, it is left unchanged.
+    """
+    if not isinstance(e.body, (str, bytes)):
+        e.body = json.dumps(e.body, indent=4)
+
+
+def _normalize_api_exc(func):
+    """Decorator: normalize ApiException body before propagating."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        from kubernetes.client import ApiException
+        try:
+            return func(*args, **kwargs)
+        except ApiException as e:
+            api_exc_normalize_body(e)
+            raise
+    return wrapper
+
 
 K8S_WARNING_HEADER = re.compile(r'(?:,\s*)?(\d{3})\s+(\S+)\s+"(.+?)(?<!\\)"(?:\s+\"(.+?)(?<!\\)\")?\s*')
 UPPER_FOLLOWED_BY_LOWER_RE = re.compile(r"(.)([A-Z][a-z]+)")
@@ -179,6 +218,7 @@ class K8SResourceDef:
         self._api_create = None
         self._api_patch = None
         self._api_delete = None
+        self._api_list = None
 
     @property
     def group(self) -> str:
@@ -211,6 +251,10 @@ class K8SResourceDef:
     @property
     def delete(self):
         return self._api_delete
+
+    @property
+    def list(self):
+        return self._api_list
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, K8SResourceDef):
@@ -291,11 +335,13 @@ class K8SResourceDef:
                 self._api_patch = partial(k8s_api.patch_namespaced_custom_object, **kwargs)
                 self._api_create = partial(k8s_api.create_namespaced_custom_object, **kwargs)
                 self._api_delete = partial(k8s_api.delete_namespaced_custom_object, **kwargs)
+                self._api_list = partial(k8s_api.list_namespaced_custom_object, **kwargs)
             else:
                 self._api_get = partial(k8s_api.get_cluster_custom_object, **kwargs)
                 self._api_patch = partial(k8s_api.patch_cluster_custom_object, **kwargs)
                 self._api_create = partial(k8s_api.create_cluster_custom_object, **kwargs)
                 self._api_delete = partial(k8s_api.delete_cluster_custom_object, **kwargs)
+                self._api_list = partial(k8s_api.list_cluster_custom_object, **kwargs)
         else:
             # Take care for the case e.g. api_type is "apiextensions.k8s.io"
             # Only replace the last instance
@@ -316,11 +362,13 @@ class K8SResourceDef:
                 self._api_patch = getattr(k8s_api, f"patch_namespaced_{kind}")
                 self._api_create = getattr(k8s_api, f"create_namespaced_{kind}")
                 self._api_delete = getattr(k8s_api, f"delete_namespaced_{kind}")
+                self._api_list = getattr(k8s_api, f"list_namespaced_{kind}")
             else:
                 self._api_get = getattr(k8s_api, f"read_{kind}")
                 self._api_patch = getattr(k8s_api, f"patch_{kind}")
                 self._api_create = getattr(k8s_api, f"create_{kind}")
                 self._api_delete = getattr(k8s_api, f"delete_{kind}")
+                self._api_list = getattr(k8s_api, f"list_{kind}")
 
 
 class K8SResourceKey(namedtuple("K8SResourceKey", ["group", "kind", "name", "namespace"])):
@@ -390,6 +438,7 @@ class K8SResource:
     def __str__(self):
         return f"{self.api_version}/{self.kind}/{self.name}{'.' + self.namespace if self.namespace else ''}"
 
+    @_normalize_api_exc
     def get(self):
         rdef = self.rdef
         kwargs = {"name": self.name,
@@ -398,6 +447,7 @@ class K8SResource:
             kwargs["namespace"] = self.namespace
         return json.loads(self.rdef.get(**kwargs).data)
 
+    @_normalize_api_exc
     def create(self, dry_run=True):
         rdef = self.rdef
         kwargs = {"body": self.manifest,
@@ -416,6 +466,7 @@ class K8SResource:
         self._process_response_headers(resp)
         return json.loads(resp.data)
 
+    @_normalize_api_exc
     def patch(self, json_patch, *, patch_type: K8SResourcePatchType, force=False, dry_run=True):
         rdef = self.rdef
         kwargs = {"name": self.name,
@@ -455,7 +506,9 @@ class K8SResource:
         finally:
             api_client.select_header_content_type = old_func
 
-    def delete(self, *, dry_run=True, propagation_policy=K8SPropagationPolicy.BACKGROUND):
+    @_normalize_api_exc
+    def delete(self, *, dry_run=True, propagation_policy=K8SPropagationPolicy.BACKGROUND, wait=True):
+        from kubernetes.client import ApiException
         rdef = self.rdef
         kwargs = {"name": self.name,
                   "_preload_content": False,
@@ -466,7 +519,35 @@ class K8SResource:
         if dry_run:
             kwargs["dry_run"] = "All"
 
-        return json.loads(rdef.delete(**kwargs).data)
+        result = json.loads(rdef.delete(**kwargs).data)
+
+        if wait and not dry_run:
+            # Wait for the resource to actually disappear by watching for the
+            # DELETED event. If the resource is already gone before the watch
+            # opens (race), the watch produces no events; loop with a short
+            # server-side timeout and re-check existence via get() to break out.
+            while True:
+                for event in self.watch(timeout_seconds=10):
+                    if event["type"] == "DELETED":
+                        return result
+                try:
+                    self.get()
+                except ApiException as e:
+                    if e.status == 404:
+                        return result
+                    raise
+
+        return result
+
+    def watch(self, *, timeout_seconds=None):
+        from kubernetes import watch as k8s_watch
+        rdef = self.rdef
+        kwargs = {"field_selector": f"metadata.name={self.name}"}
+        if rdef.namespaced:
+            kwargs["namespace"] = self.namespace
+        if timeout_seconds is not None:
+            kwargs["timeout_seconds"] = timeout_seconds
+        return k8s_watch.Watch().stream(rdef.list, **kwargs)
 
     @staticmethod
     def get_manifest_key(manifest):

--- a/src/unittest/python/k8s_apply_retry_tests.py
+++ b/src/unittest/python/k8s_apply_retry_tests.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import json
+import unittest
+from unittest.mock import MagicMock
+
+
+def _make_api_exception(status, reason, message="boom"):
+    from kubernetes.client import ApiException
+    e = ApiException(status=status)
+    e.body = json.dumps({"reason": reason, "message": message,
+                         "status": "Failure", "details": {}})
+    e.headers = {"content-type": "application/json"}
+    return e
+
+
+class K8sApplyRetryTest(unittest.TestCase):
+    def _make_resource(self, *, name="cm", namespace="default",
+                       remote_data="old", merged_data="new"):
+        from kubernator.plugins.k8s_api import K8SResource, K8SResourceDef, K8SResourceDefKey
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                    "metadata": {"name": name, "namespace": namespace},
+                    "data": {"a": merged_data, "b": "x"}}
+        rdef = K8SResourceDef(K8SResourceDefKey("", "v1", "ConfigMap"),
+                              "configmap", "configmaps", True, False, None)
+        rdef.populate_api = MagicMock()  # bypass real client wiring
+
+        resource = K8SResource(manifest, rdef, source="unit")
+        # Mock cluster I/O
+        resource.get = MagicMock(return_value={
+            "apiVersion": "v1", "kind": "ConfigMap",
+            "metadata": {"name": name, "namespace": namespace,
+                         "uid": "u1", "resourceVersion": "1"},
+            "data": {"a": remote_data, "b": "x"}})
+        # SSA dry-run merge: returns server's view; resourceVersion advances per call
+        merged_v2 = {"apiVersion": "v1", "kind": "ConfigMap",
+                     "metadata": {"name": name, "namespace": namespace,
+                                  "uid": "u1", "resourceVersion": "2"},
+                     "data": {"a": merged_data, "b": "x"}}
+        merged_v3 = {"apiVersion": "v1", "kind": "ConfigMap",
+                     "metadata": {"name": name, "namespace": namespace,
+                                  "uid": "u1", "resourceVersion": "3"},
+                     "data": {"a": merged_data, "b": "x"}}
+        resource.patch = MagicMock(side_effect=[merged_v2, merged_v3])
+        return resource
+
+    def _make_plugin(self):
+        plugin = MagicMock()
+        plugin.context.k8s.client = MagicMock()
+        plugin.context.k8s.immutable_changes = {}
+        plugin._filter_resource_patch = lambda patch, excludes: list(patch)
+        return plugin
+
+    def test_409_on_patch_triggers_retry_and_succeeds(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        resource = self._make_resource()
+
+        applied_manifest = {"applied": True}
+        patch_func = MagicMock(side_effect=[
+            _make_api_exception(409, "Conflict", "stale resourceVersion"),
+            applied_manifest,
+        ])
+        create_func = MagicMock()
+        delete_func = MagicMock()
+
+        result = KubernetesPlugin._apply_resource(
+            plugin, False, [], resource,
+            patch_func, create_func, delete_func, "")
+
+        self.assertEqual(result, (0, 1, 0, applied_manifest))
+        # patch_func called twice: first 409, then success
+        self.assertEqual(patch_func.call_count, 2)
+        # SSA dry-run merge re-issued on retry to compute a fresh patch
+        self.assertEqual(resource.patch.call_count, 2)
+        # No create or delete should have happened
+        create_func.assert_not_called()
+        delete_func.assert_not_called()
+
+    def test_non_409_exception_on_patch_propagates_without_retry(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        resource = self._make_resource()
+
+        patch_func = MagicMock(side_effect=[
+            _make_api_exception(500, "InternalError", "kaboom"),
+        ])
+        create_func = MagicMock()
+        delete_func = MagicMock()
+
+        with self.assertRaises(Exception) as ctx:
+            KubernetesPlugin._apply_resource(
+                plugin, False, [], resource,
+                patch_func, create_func, delete_func, "")
+
+        self.assertEqual(getattr(ctx.exception, "status", None), 500)
+        # Single attempt, no retry
+        self.assertEqual(patch_func.call_count, 1)
+        self.assertEqual(resource.patch.call_count, 1)


### PR DESCRIPTION
## Summary

- Harden the K8s apply path with SSA-derived JSON-patch `test` ops for `/metadata/uid` and `/metadata/resourceVersion`, and wrap the SSA patch branch in a 409-retry loop that recomputes the patch on conflict.
- Extend `K8SResource` with `list()`, `watch()`, `delete(wait=True)` that uses watch + `get()` recheck, and add a `resource_generator()` extension seam on `KubernetesPlugin`.
- Add `ktor.k8s.resource(manifest)` — a fully-wired `K8SResource` factory for imperative CRUD from `.kubernator.py` scripts, bypassing the declarative apply lifecycle.
- Thread the applied manifest as a 4th return from `_apply_resource` and its inner patch/create/delete callables for external consumers.
- Move dump-file open/close from `app.py` into `KubernetesPlugin.handle_apply`; fix dump-mode `patch_func` to seed uid/RV on a copy of the local manifest by extracting them from the patch's own test ops (via `jsonpointer`), so the simulated post-patch manifest can be returned honestly.
- Rewrite `delete_create` and `resource_version_merge` integration tests as single-phase using the new imperative API, replacing `kubectl`-based phase-1 setup and the `TEST_PHASE` env re-invocation.
- Add unit test for 409 retry and integration tests for `watch()` and `resource_generator`. Port `resource_version_merge` from minikube to kind.

## Test plan

- [x] `pyb -vX run_unit_tests` (32 tests, all green — includes new `k8s_apply_retry_tests`)
- [x] `pyb -vX run_integration_tests -P integrationtest_file_glob=delete_create_tests.py` (single-phase, kind, immutable-field delete+recreate path)
- [x] `pyb -vX run_integration_tests -P integrationtest_file_glob=resource_version_merge_tests.py` (single-phase, kind, dump mode patch verification)
- [x] Full `pyb -vX run_integration_tests` suite via CI across the Python 3.10–3.14 matrix