### PR TITLE
Add project plugin v1: scope, ownership, cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ PyBuilder project — standard `src/main/python`, `src/unittest/python`,
     diff-match-patch, HTTP, etc.
   - `merge.py`, `_json_path.py`, `_k8s_client_patches.py`, `proc.py` — internals
   - `plugins/` — `awscli`, `eks`, `gke`, `helm`, `istio`, `k8s`, `k8s_api`, `k3d`,
-    `k8s_schema/`, `kind`, `kubeconfig`, `kubectl`, `minikube`, `template`, `terraform`,
-    `terragrunt`
+    `k8s_schema/`, `kind`, `kubeconfig`, `kubectl`, `minikube`, `project`, `template`,
+    `terraform`, `terragrunt`
   - `plugins/k8s_schema/` — OpenAPI validation extracted out of `k8s.py` / `k8s_api.py`.
     `make_validator(ctx, …)` returns either a `SwaggerV2Validator` or an
     `OpenAPIV3Validator`. Factory default is `openapi_version="auto"` (v3 on server
@@ -66,6 +66,41 @@ Key bits specific to this repo:
 - **App plugin directory ordering:** scans children alphabetically, filters by
   `context.app.excludes`, then re-orders the remainder by `context.app.includes` pattern
   order. Tests touching traversal should cover both exclude and include interaction.
+- **Project segments live in `App`, not on `.app`.** `context.app` is a single
+  shared `PropertyDict` inherited across every directory context (writes to
+  `cwd`/`includes`/`excludes` during `handle_before_dir` overwrite the shared
+  slot on entry and `handle_after_dir` clears transient fields). Per-directory
+  project segments are stored inside `App._project_segments`, keyed by the
+  directory's `PropertyDict` context. `ktor.app.project` reads/writes go through
+  a `ContextProperty` installed at `globals.app.project` whose `fget`/`fset`
+  are `App._get_project` / `App._set_project`; both use `self.context` (the App's
+  current directory context) to compose segments up the context chain or to
+  store the new segment on the current directory. Segment regex is
+  `[A-Za-z0-9_\-]+` (no dots, no special characters). `PropertyDict` supports
+  this via a minimal descriptor protocol — see `ContextProperty` in `api.py`.
+- **Project plugin is a switch.** Registering `project` populates
+  `context.globals.project = {root, cleanup, state_namespace}`. All tagging,
+  filtering, state Secret I/O, Lease locking, and cleanup live inside the k8s
+  plugin and gate at runtime on the presence of `globals.project`. Register the
+  project plugin *before* any resources are added — `project.register()` raises
+  when `k8s.resources` is non-empty.
+- **Project state Secret — one per root.** The k8s plugin stores a gzipped JSON
+  payload inside a single `Secret` named `kubernator-project-<sha1(root)[:12]>`
+  of type `kubernator.io/project-state`, in the configured `state_namespace`
+  (default `kubernator-system`). Two-phase write: pre-apply sets
+  `pending=new_intent, finalized=false`; post-cleanup sets `resources=...,
+  finalized=true`. A run that crashes mid-flight leaves `finalized=false`; the
+  next run's cleanup takes the conservative union (resources ∪ pending) so no
+  previously-owned resource leaks.
+- **Cluster lock via Lease.** `coordination.k8s.io/v1.Lease` named
+  `kubernator-project-<sha1(root)[:12]>-lock` serializes concurrent project
+  runs against the same root. Acquired at the start of `k8s.handle_apply`,
+  renewed every 20 s by a gevent greenlet, released in `k8s.handle_shutdown`
+  (always-fires). Stale leases (expired `renewTime + leaseDurationSeconds`)
+  are taken over; fresh leases fail the incoming run fast.
+- **`handle_cleanup` lifecycle stage.** Runs after `handle_verify` and before
+  `handle_shutdown`. Verify failures abort before cleanup so a future rollback
+  feature only has to undo applies/patches.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ kubernator [OPTIONS] [dump|apply]
 | `-o, --output-format {json,json-pretty,yaml}` | Output format. Default `yaml`.                                       |
 | `-p, --path PATH`                    | Starting directory. Default current directory.                                 |
 | `--yes`                              | Actually apply changes. Without this flag Kubernator runs as a dry-run.        |
+| `-I, --include-project PROJECT`      | Repeatable. Limit the run to the named project and its sub-tree. No-op unless the `project` plugin is registered. |
+| `-X, --exclude-project PROJECT`      | Repeatable. Exclude the named project and its sub-tree. No-op unless the `project` plugin is registered. |
 | `command`                            | `dump` (default) writes the computed plan; `apply` applies it to the cluster.  |
 
 ## Mode of Operation
@@ -150,8 +152,9 @@ The pipeline stages, in order, are:
     3. **After Directory** — every plugin's `handle_after_dir` (reverse order).
 4. **Apply** — every plugin's `handle_apply` (e.g. Kubernetes plugin pushes resources to the cluster when `--yes`).
 5. **Verify** — every plugin's `handle_verify`.
-6. **Shutdown** — every plugin's `handle_shutdown` (cleanups, even on failure).
-7. **Summary** — every plugin's `handle_summary` (on success only).
+6. **Cleanup** — every plugin's `handle_cleanup` (runs after verify, so verify failures prevent cleanup).
+7. **Shutdown** — every plugin's `handle_shutdown` (cleanups, even on failure).
+8. **Summary** — every plugin's `handle_summary` (on success only).
 
 Within "for each directory", after `after_dir` fires, the app plugin scans the current directory for sub-directories,
 filters them through `context.app.excludes`, re-orders the survivors according to `context.app.includes` patterns, and
@@ -198,6 +201,7 @@ any), and whether Kubernator downloads that binary automatically given a version
 | `helm`       | Renders Helm charts (classic repo and OCI) into K8s resources.   | `helm`       | Yes              |
 | `istio`      | Installs and upgrades Istio via `istioctl`/IstioOperator.        | `istioctl`   | Yes              |
 | `templates`  | Registers and renders Jinja2 templates that emit K8s resources.  | —            | —                |
+| `project`    | Scopes, tracks ownership, and cleans up resources by a hierarchical project name. | — | — |
 
 ### App Plugin (`app`)
 
@@ -456,6 +460,10 @@ File discovery uses globs `*.yaml` / `*.yml` by default, configurable per-direct
   `func(resources, resource)` that may mutate manifests before apply.
 * `ktor.k8s.add_validator(func)` — register a validator run after transformation.
 * `ktor.k8s.add_manifest_patcher(func)` — register a low-level manifest patcher.
+* `ktor.k8s.add_resource_filter(predicate)` / `ktor.k8s.remove_resource_filter(predicate)` — register/remove a
+  predicate `predicate(resource)` consulted by `resource_generator()`; returning `False` skips the resource.
+  Used internally by the `project` plugin for `-I`/`-X` scoping, but available to any script that needs
+  declarative filtering without overriding the generator.
 * `ktor.k8s.get_api_versions()` — set of `(group, version)` tuples in use.
 * `ktor.k8s.create_resource(manifest)` — wrap a manifest as a `K8SResource` without registering it.
 * `ktor.k8s.resource(manifest)` — return a fully-wired `K8SResource` with API bindings populated, for
@@ -526,6 +534,38 @@ Installs and upgrades Istio using `istioctl` against an `IstioOperator` resource
 * `ktor.istio.default_includes`, `ktor.istio.default_excludes`, `ktor.istio.includes`, `ktor.istio.excludes`
 * `ktor.istio.istioctl_file`, `ktor.istio.stanza()`
 * `ktor.istio.test()` — run `istioctl version`, returning `(version_tuple, full_output_dict)`.
+
+### Project Plugin (`project`)
+
+Introduces hierarchical ownership, scoping, and cleanup for Kubernator-managed resources. Register once at the root with a `name` — that name becomes the root of the project tree. Sub-directories extend the tree by assigning `ktor.app.project = "<segment>"` in their `.kubernator.py`; segments are dot-joined top-down into the full project path (e.g. `demo.api.frontend`). Segment regex is `[A-Za-z0-9_\-]+` — no dots, no special characters. Must be registered **before** any resources are added; `project.register()` raises if the `k8s` plugin already has resources.
+
+```python
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("project", name="demo", cleanup=True)
+# later, in a subdir
+ktor.app.project = "api"
+```
+
+Once registered, the k8s plugin:
+
+- stamps every applied resource with a `kubernator.io/project` annotation carrying the composed path;
+- honours `-I`/`-X` CLI flags to scope the run to specific sub-trees (prefix match; combined as `candidates = known ∩ includes` then `in_scope = candidates − excludes`);
+- records a per-root state Secret at `<state_namespace>/kubernator-project-<sha1(root)[:12]>` (default namespace `kubernator-system`) containing a gzipped JSON payload of the owned resources' idents;
+- on each run, diffs the prior Secret against the current manifest set and (when `cleanup=True`) deletes resources that used to belong to an in-scope sub-project but no longer do;
+- serialises concurrent runs against the same root via a `coordination.k8s.io/v1.Lease` named `kubernator-project-<sha1(root)[:12]>-lock` in the same namespace.
+
+The Secret write is two-phase: before `apply` the new intent is recorded as `pending` with `finalized=false`; after successful apply + cleanup the finalized payload replaces it. A crash between the two phases leaves `finalized=false`; the next run's cleanup conservatively unions prior `resources ∪ pending`, so no previously-owned resource leaks.
+
+#### `register_plugin` keyword arguments
+
+* `name` *(required)* — segment assigned at the current context's `.app.project`. Also the root of the project tree when registered at the top level.
+* `cleanup=False` — if `True`, delete resources present in the prior Secret but absent from the current in-scope manifests. If `False`, diffs are logged but nothing is deleted.
+* `state_namespace="kubernator-system"` — namespace for the state Secret and the Lease. Auto-created by the k8s plugin on a committed (non-dry-run) invocation.
+
+#### Context
+
+* `ktor.app.project`
+  > The composed project path at the current context, or `None` if no segment is set anywhere in the chain. Read-only unless you know what you're doing — the descriptor enforces single-assignment per context and validates segment syntax.
 
 ### Templates Plugin (`templates`)
 

--- a/src/integrationtest/python/project_v1/phase1/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase1/.kubernator.py
@@ -1,0 +1,25 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="project-v1",
+                         start_fresh=True,
+                         keep_running=True)
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("project", name="demo", cleanup=True)
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-ns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cfg
+  namespace: demo-ns
+data:
+  phase: "1"
+""")

--- a/src/integrationtest/python/project_v1/phase1/sub_a/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase1/sub_a/.kubernator.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+ktor.app.project = "a"
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-cfg-1
+  namespace: demo-ns
+data:
+  phase: "1"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-cfg-2
+  namespace: demo-ns
+data:
+  phase: "1"
+""")

--- a/src/integrationtest/python/project_v1/phase1/sub_b/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase1/sub_b/.kubernator.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+ktor.app.project = "b"
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-cfg-1
+  namespace: demo-ns
+data:
+  phase: "1"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-cfg-2
+  namespace: demo-ns
+data:
+  phase: "1"
+""")

--- a/src/integrationtest/python/project_v1/phase2/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase2/.kubernator.py
@@ -1,0 +1,25 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind",
+                         k8s_version=os.environ["K8S_VERSION"],
+                         profile="project-v1",
+                         start_fresh=False,
+                         keep_running=True)
+ktor.app.register_plugin("k8s")
+ktor.app.register_plugin("project", name="demo", cleanup=True)
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-ns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cfg
+  namespace: demo-ns
+data:
+  phase: "2"
+""")

--- a/src/integrationtest/python/project_v1/phase2/sub_a/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase2/sub_a/.kubernator.py
@@ -1,0 +1,14 @@
+# flake8: noqa
+ktor.app.project = "a"
+
+# Phase 2 drops a-cfg-2 — it should be deleted by the cleanup phase because
+# prior-run state Secret recorded it for project "demo.a".
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-cfg-1
+  namespace: demo-ns
+data:
+  phase: "2"
+""")

--- a/src/integrationtest/python/project_v1/phase2/sub_b/.kubernator.py
+++ b/src/integrationtest/python/project_v1/phase2/sub_b/.kubernator.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+ktor.app.project = "b"
+
+ktor.k8s.add_resources("""
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-cfg-1
+  namespace: demo-ns
+data:
+  phase: "2"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-cfg-2
+  namespace: demo-ns
+data:
+  phase: "2"
+""")

--- a/src/integrationtest/python/project_v1_tests.py
+++ b/src/integrationtest/python/project_v1_tests.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+import os  # noqa: E402
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+KIND_KUBECONFIG_PATH = Path.home() / ".cache" / "kubernator" / "kind" / ".kube" / "project-v1" / "config"
+
+
+class ProjectV1Test(IntegrationTestSupport):
+    """Exercises the project plugin v1 end-to-end: multi-sub-project hierarchy
+    → apply with cleanup=True → remove one resource → re-apply → removed
+    resource gets deleted by the cleanup pass, while resources that stayed or
+    moved between projects survive.
+    """
+
+    def _kubectl_configmap_names(self, namespace):
+        env = dict(os.environ)
+        env["KUBECONFIG"] = str(KIND_KUBECONFIG_PATH)
+        out = subprocess.check_output(
+            ["kubectl", "get", "configmap", "-n", namespace,
+             "-o", "jsonpath={.items[*].metadata.name}"],
+            env=env,
+            text=True,
+        )
+        return set(n for n in out.split() if n)
+
+    def _kubectl_configmap_annotation(self, namespace, name, annotation):
+        env = dict(os.environ)
+        env["KUBECONFIG"] = str(KIND_KUBECONFIG_PATH)
+        return subprocess.check_output(
+            ["kubectl", "get", "configmap", "-n", namespace, name,
+             "-o", "jsonpath={.metadata.annotations." +
+             annotation.replace(".", "\\.") + "}"],
+            env=env,
+            text=True,
+        ).strip()
+
+    def _kind_delete_cluster(self, profile):
+        try:
+            subprocess.run(["kind", "delete", "cluster", "--name", profile],
+                           check=False, timeout=120)
+        except Exception:
+            pass
+
+    def test_project_v1_cleanup_deletes_removed_resource(self):
+        test_dir = Path(__file__).parent / "project_v1"
+        phase1 = test_dir / "phase1"
+        phase2 = test_dir / "phase2"
+
+        for k8s_version in (self.K8S_TEST_VERSIONS[-1],):
+            with self.subTest(k8s_version=k8s_version):
+                os.environ["K8S_VERSION"] = k8s_version
+                try:
+                    # Phase 1: apply a hierarchy with three sub-project
+                    # levels' worth of resources (demo, demo.a, demo.b).
+                    self.run_module_test(
+                        "kubernator", "-p", str(phase1), "-v", "TRACE",
+                        "apply", "--yes")
+
+                    names_after_phase1 = self._kubectl_configmap_names("demo-ns")
+                    self.assertEqual(
+                        names_after_phase1,
+                        {"root-cfg", "a-cfg-1", "a-cfg-2", "b-cfg-1", "b-cfg-2",
+                         # kube-root-ca.crt is auto-created per namespace
+                         # from 1.20+.
+                         "kube-root-ca.crt"},
+                    )
+
+                    # Annotations should carry the dotted project path.
+                    self.assertEqual(
+                        self._kubectl_configmap_annotation(
+                            "demo-ns", "a-cfg-1", "kubernator.io/project"),
+                        "demo.a")
+                    self.assertEqual(
+                        self._kubectl_configmap_annotation(
+                            "demo-ns", "b-cfg-2", "kubernator.io/project"),
+                        "demo.b")
+
+                    # Phase 2: drops a-cfg-2 from the manifests.
+                    self.run_module_test(
+                        "kubernator", "-p", str(phase2), "-v", "TRACE",
+                        "apply", "--yes")
+
+                    names_after_phase2 = self._kubectl_configmap_names("demo-ns")
+                    expected = {"root-cfg", "a-cfg-1", "b-cfg-1", "b-cfg-2",
+                                "kube-root-ca.crt"}
+                    self.assertEqual(
+                        names_after_phase2, expected,
+                        "a-cfg-2 should have been deleted by the cleanup "
+                        "pass based on the prior state Secret.")
+                finally:
+                    self._kind_delete_cluster("project-v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/kubernator/api.py
+++ b/src/main/python/kubernator/api.py
@@ -470,18 +470,41 @@ class _PropertyList(MutableSequence):
             setattr(self.__write_parent, self.__name, self.__write_seq)
 
 
+class ContextProperty:
+    """Callable descriptor stored as a value in a PropertyDict. When any
+    PropertyDict in the ancestor chain holds a ``ContextProperty`` under the
+    accessed name, attribute access is dispatched here with the *origin*
+    PropertyDict (the one the access started from), so the descriptor can
+    walk the chain upward itself."""
+
+    __slots__ = ("fget", "fset")
+
+    def __init__(self, fget, fset=None):
+        self.fget = fget
+        self.fset = fset
+
+
 class PropertyDict:
+    # Names ever installed as a ``ContextProperty`` on any PropertyDict. The
+    # fast path in ``__getattr__``/``__setattr__`` skips the full-chain walk
+    # for names that are never descriptors — which is the overwhelming
+    # majority of attribute accesses in practice.
+    _descriptor_names: set = set()
+
     def __init__(self, _dict=None, _parent=None):
         self.__dict__["_PropertyDict__dict"] = _dict or {}
         self.__dict__["_PropertyDict__parent"] = _parent
 
     def __getattr__(self, item):
-        v = self.__getattr(item)
+        if item in PropertyDict._descriptor_names:
+            v = self.__descriptor_getattr(item, self)
+        else:
+            v = self.__plain_getattr(item)
         if isinstance(v, _PropertyList):
             v._PropertyList__write_parent = self
         return v
 
-    def __getattr(self, item):
+    def __plain_getattr(self, item):
         try:
             v = self.__dict[item]
             if isinstance(v, list):
@@ -490,12 +513,47 @@ class PropertyDict:
         except KeyError:
             parent = self.__parent
             if parent is not None:
-                return parent.__getattr(item)
+                return parent._PropertyDict__plain_getattr(item)
             raise AttributeError("no attribute %r" % item) from None
+
+    def __descriptor_getattr(self, item, origin):
+        first_layer = None
+        first_value = None
+        found_raw = False
+        cur = self
+        while cur is not None:
+            d = cur._PropertyDict__dict
+            if item in d:
+                v = d[item]
+                if isinstance(v, ContextProperty):
+                    return v.fget(origin)
+                if not found_raw:
+                    first_layer = cur
+                    first_value = v
+                    found_raw = True
+            cur = cur._PropertyDict__parent
+        if found_raw:
+            if isinstance(first_value, list):
+                return _PropertyList(first_value, first_layer, item)
+            return first_value
+        raise AttributeError("no attribute %r" % item) from None
 
     def __setattr__(self, key, value):
         if key.startswith("_PropertyDict__"):
             raise AttributeError("prohibited attribute %r" % key)
+        if key in PropertyDict._descriptor_names:
+            cur = self
+            while cur is not None:
+                d = cur._PropertyDict__dict
+                if key in d and isinstance(d[key], ContextProperty):
+                    descriptor = d[key]
+                    if descriptor.fset is None:
+                        raise AttributeError("%s is read-only" % key)
+                    descriptor.fset(self, value)
+                    return
+                cur = cur._PropertyDict__parent
+        if isinstance(value, ContextProperty):
+            PropertyDict._descriptor_names.add(key)
         if isinstance(value, dict):
             parent_dict = None
             if self.__parent is not None:
@@ -823,6 +881,9 @@ class KubernatorPlugin:
         pass
 
     def handle_verify(self):
+        pass
+
+    def handle_cleanup(self):
         pass
 
     def handle_shutdown(self):

--- a/src/main/python/kubernator/app.py
+++ b/src/main/python/kubernator/app.py
@@ -21,6 +21,7 @@ import datetime
 import importlib
 import logging
 import pkgutil
+import re
 import sys
 import urllib.parse
 from collections import deque
@@ -34,6 +35,7 @@ import yaml
 
 import kubernator
 from kubernator.api import (KubernatorPlugin, Globs, scan_dir, PropertyDict, config_as_dict, config_parent,
+                            ContextProperty,
                             download_remote_file, load_remote_file, Repository, StripNL, jp, get_app_cache_dir,
                             get_cache_dir, install_python_k8s_client)
 from kubernator.proc import run, run_capturing_out, run_pass_through_capturing
@@ -62,6 +64,9 @@ try:
     del (yaml.resolver.Resolver.yaml_implicit_resolvers["="])
 except KeyError:
     pass
+
+
+_PROJECT_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 
 def define_arg_parse():
@@ -99,6 +104,14 @@ def define_arg_parse():
     #                        help="specify a version of Kubernetes when operating in the disconnected mode")
     parser.add_argument("--yes", action="store_false", default=True, dest="dry_run",
                         help="actually make destructive changes")
+    parser.add_argument("-I", "--include-project", action="append", default=[],
+                        metavar="PROJECT", dest="include_project",
+                        help="limit the run to the named project and its sub-tree "
+                             "(repeatable; no-op unless the project plugin is registered)")
+    parser.add_argument("-X", "--exclude-project", action="append", default=[],
+                        metavar="PROJECT", dest="exclude_project",
+                        help="exclude the named project and its sub-tree "
+                             "(repeatable; no-op unless the project plugin is registered)")
     parser.add_argument("command", nargs="?", choices=["dump", "apply"], default="dump",
                         help="whether to dump the proposed changes to the output or to apply them")
     return parser
@@ -166,6 +179,7 @@ class App(KubernatorPlugin):
 
         self._cleanups = []
         self._plugin_types = {}
+        self._project_segments: dict[PropertyDict, str] = {}
 
     def __enter__(self):
         return self
@@ -212,6 +226,9 @@ class App(KubernatorPlugin):
                 self._run_handlers(KubernatorPlugin.handle_apply, True, context, None)
 
                 self._run_handlers(KubernatorPlugin.handle_verify, True, context, None)
+
+                # Cleanup runs after verify so a verify failure prevents cleanup.
+                self._run_handlers(KubernatorPlugin.handle_cleanup, True, context, None)
             finally:
                 self.context = self._top_dir_context
                 context = self.context
@@ -315,13 +332,18 @@ class App(KubernatorPlugin):
             __plugin.set_context(__context)
             run(__plugin)
         else:
-            self._set_plugin_context(__reverse, __context, run)
+            self._dispatch_to_all_plugins(__reverse, __context, run)
 
-    def _set_plugin_context(self, reverse, context, run):
-        for h in list(self.context._plugins if not reverse else reversed(self.context._plugins)):
+    def _dispatch_to_all_plugins(self, reverse, context, run):
+        plugins = list(self.context._plugins if not reverse else reversed(self.context._plugins))
+        for h in plugins:
             h.set_context(context)
-            run(h)
-            h.set_context(None)
+        try:
+            for h in plugins:
+                run(h)
+        finally:
+            for h in plugins:
+                h.set_context(None)
 
     def _exec_ktor(self, ktor_py: Path):
         ktor_py_display_path = self._display_path(ktor_py)
@@ -378,12 +400,36 @@ class App(KubernatorPlugin):
                                    default_includes=Globs(["*"], True),
                                    default_excludes=Globs([".*"], True),
                                    )
+        context.globals.app.project = ContextProperty(self._get_project, self._set_project)
+
         context.app = dict(_repository_credentials_provider=None,
                            default_includes=Globs(context.app.default_includes),
                            default_excludes=Globs(context.app.default_excludes),
                            includes=Globs(context.app.default_includes),
                            excludes=Globs(context.app.default_excludes),
                            )
+
+    def _get_project(self, origin):
+        segs = []
+        cur = self.context
+        while cur is not None:
+            seg = self._project_segments.get(cur)
+            if seg is not None:
+                segs.append(seg)
+            cur = config_parent(cur)
+        if not segs:
+            return None
+        segs.reverse()
+        return ".".join(segs)
+
+    def _set_project(self, origin, value):
+        if not isinstance(value, str) or not _PROJECT_SEGMENT_RE.match(value):
+            raise ValueError("invalid project segment %r" % (value,))
+        ctx = self.context
+        if ctx in self._project_segments:
+            raise ValueError("project already set to %r in this context" %
+                             (self._project_segments[ctx],))
+        self._project_segments[ctx] = value
 
     def handle_before_dir(self, cwd: Path):
         context = self.context
@@ -413,6 +459,19 @@ class App(KubernatorPlugin):
         self.path_q.extend(reversed(self._new_paths))
 
         del app.cwd
+
+    def handle_summary(self):
+        if "project" in self.context.globals:
+            return
+        args = self.args
+        unused = ["%s %s" % (flag, val)
+                  for flag, val in (("-I/--include-project", args.include_project),
+                                    ("-X/--exclude-project", args.exclude_project))
+                  if val]
+        if unused:
+            logger.warning(
+                "Project scoping flag(s) %s had no effect because the project "
+                "plugin was not registered in this run.", ", ".join(unused))
 
     def repository(self, repo):
         repository = Repository(repo, self._repo_cred_augmentation)

--- a/src/main/python/kubernator/plugins/k8s.py
+++ b/src/main/python/kubernator/plugins/k8s.py
@@ -17,17 +17,25 @@
 #
 
 
+import base64
+import gzip
+import hashlib
 import json
 import logging
+import os
 import re
+import socket
 import sys
 import types
+import uuid
 from collections.abc import Mapping
-from functools import partial
+from datetime import datetime, timedelta, timezone
+from functools import partial, wraps
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Iterable, Callable, Sequence, Optional
 
+import gevent
 import jsonpatch
 import yaml
 
@@ -45,9 +53,12 @@ from kubernator.merge import extract_merge_instructions, apply_merge_instruction
 from kubernator.plugins import k8s_schema
 from kubernator.plugins.k8s_api import (K8SResourcePluginMixin,
                                         K8SResource,
+                                        K8SResourceKey,
                                         K8SResourcePatchType,
                                         K8SPropagationPolicy,
-                                        api_exc_format_body)
+                                        PROJECT_ANNOTATION,
+                                        api_exc_format_body,
+                                        api_exc_normalize_body)
 
 logger = logging.getLogger("kubernator.k8s")
 proc_logger = logger.getChild("proc")
@@ -56,6 +67,108 @@ stderr_logger = StripNL(proc_logger.warning)
 
 FIELD_VALIDATION_STRICT_MARKER = "strict decoding error: "
 VALID_FIELD_VALIDATION = ("Ignore", "Warn", "Strict")
+
+PROJECT_STATE_VERSION = "1"
+PROJECT_STATE_SECRET_TYPE = "kubernator.io/project-state"
+PROJECT_STATE_SECRET_DATA_KEY = "state"
+PROJECT_ROOT_ANNOTATION = "kubernator.io/project-root"
+PROJECT_LEASE_DURATION_SECONDS = 60
+PROJECT_LEASE_RENEW_INTERVAL_SECONDS = 20
+PROJECT_LEASE_ACQUIRE_ATTEMPTS = 3
+
+# State Secret payload fields — also kept as constants so the wire format
+# is changed through a single declaration.
+_STATE_VERSION = "version"
+_STATE_FINALIZED = "finalized"
+_STATE_RESOURCES = "resources"
+_STATE_PENDING = "pending"
+
+
+def _project_matches(p: str, q: str) -> bool:
+    """Prefix match: ``p`` matches ``q`` iff ``p == q`` or ``p`` starts with
+    ``q + "."``. Sub-projects of ``q`` are considered matches."""
+    return p == q or p.startswith(q + ".")
+
+
+def _root_hash(root: str) -> str:
+    return hashlib.sha1(root.encode("utf-8")).hexdigest()[:12]
+
+
+def _state_secret_name(root: str) -> str:
+    return "kubernator-project-%s" % (_root_hash(root),)
+
+
+def _lease_name(root: str) -> str:
+    return "kubernator-project-%s-lock" % (_root_hash(root),)
+
+
+def _resource_ident(resource: K8SResource) -> dict:
+    """Minimal identifier dict for a K8SResource — enough to delete it on a
+    subsequent run. ``version`` is needed to build ``apiVersion`` for the
+    delete call; it is intentionally excluded from ``_ident_key`` so that a
+    CRD version bump doesn't spuriously mark a resource obsolete."""
+    key = resource.key
+    ident = {
+        "group": key.group or "",
+        "version": resource.rdef.version,
+        "kind": key.kind,
+        "name": key.name,
+    }
+    if key.namespace:
+        ident["namespace"] = key.namespace
+    return ident
+
+
+def _ident_key(ident: dict) -> K8SResourceKey:
+    return K8SResourceKey(ident.get("group", ""),
+                          ident.get("kind", ""),
+                          ident.get("name", ""),
+                          ident.get("namespace"))
+
+
+def _encode_state(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    compressed = gzip.compress(raw, compresslevel=6)
+    return base64.b64encode(compressed).decode("ascii")
+
+
+def _decode_state(encoded: str) -> dict:
+    compressed = base64.b64decode(encoded.encode("ascii"))
+    raw = gzip.decompress(compressed)
+    return json.loads(raw.decode("utf-8"))
+
+
+def _empty_state_payload() -> dict:
+    return {
+        _STATE_VERSION: PROJECT_STATE_VERSION,
+        _STATE_FINALIZED: True,
+        _STATE_RESOURCES: {},
+        _STATE_PENDING: {},
+    }
+
+
+def _lease_identity() -> str:
+    """Return a unique identifier for this run — hostname-pid-uuid4."""
+    return "%s-%d-%s" % (socket.gethostname(), os.getpid(), uuid.uuid4().hex[:8])
+
+
+def _pretty_api_exc(func):
+    """Decorator: normalize then pretty-format any ``ApiException`` that
+    propagates out, so logs and error traces see indented JSON instead of
+    raw bytes or ``dict`` reprs. Matches the ``_normalize_api_exc`` /
+    ``api_exc_format_body`` pattern used elsewhere in k8s_api.py."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        from kubernetes.client.rest import ApiException
+        try:
+            return func(*args, **kwargs)
+        except ApiException as e:
+            api_exc_normalize_body(e)
+            api_exc_format_body(e)
+            raise
+
+    return wrapper
 
 
 def final_resource_validator(resources: Sequence[K8SResource],
@@ -99,8 +212,21 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         self._transformers = []
         self._validators = []
         self._manifest_patchers = []
+        self._resource_filters = []
         self._summary = 0, 0, 0
         self._template_engine = TemplateEngine(logger)
+        self._in_scope_projects: Optional[set] = None
+        # Project-run state, populated when the project plugin switch is on.
+        self._project_lease_identity: Optional[str] = None
+        self._project_lease_acquired = False
+        self._project_lease_renewer: Optional[gevent.Greenlet] = None
+        self._project_lease_abort = False
+        self._project_prior_state: Optional[dict] = None
+        self._project_new_intent: Optional[dict] = None
+        # Cached resourceVersion for the state Secret, populated by the first
+        # read and refreshed after each write so subsequent writes skip their
+        # own GETs.
+        self._project_state_rv: Optional[str] = None
 
     def set_context(self, context):
         self.context = context
@@ -146,8 +272,11 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                    load_remote_crds=self.api_load_remote_crds,
                                    add_transformer=self.api_add_transformer,
                                    remove_transformer=self.api_remove_transformer,
-                                   add_validator=self.api_remove_validator,
+                                   add_validator=self.api_add_validator,
+                                   remove_validator=self.api_remove_validator,
                                    add_manifest_patcher=self.api_add_manifest_patcher,
+                                   add_resource_filter=self.api_add_resource_filter,
+                                   remove_resource_filter=self.api_remove_resource_filter,
                                    get_api_versions=self.get_api_versions,
                                    create_resource=self.create_resource,
                                    disable_client_patches=disable_client_patches,
@@ -163,6 +292,10 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                            default_excludes=Globs(context.globals.k8s.default_excludes)
                            )
         self.api_add_validator(final_resource_validator)
+        # Project hooks are always installed; they gate at runtime on
+        # ``"project" in self.context.globals``.
+        self.api_add_manifest_patcher(self._project_annotation_patcher)
+        self.api_add_resource_filter(self._project_resource_filter)
 
     def handle_init(self):
         pass
@@ -206,6 +339,15 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
 
     def _setup_client(self):
         from kubernetes import client
+        from kubernetes.client.rest import RESTResponse
+
+        # Upstream v35 client's exceptions.py reads ``http_resp.headers`` but
+        # RESTResponse only defines ``getheaders()``, so any failed API call
+        # that takes the default (``_preload_content=True``) wrapping path
+        # raises ``AttributeError`` inside ``ApiException.__init__`` instead
+        # of surfacing the actual error. Alias the attribute once.
+        if not hasattr(RESTResponse, "headers"):
+            RESTResponse.headers = property(lambda self: self.getheaders())
 
         context = self.context
         k8s = context.k8s
@@ -264,7 +406,9 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                     self.add_resource(manifest, display_p)
 
     def resource_generator(self):
-        yield from self.resources.values()
+        for r in self.resources.values():
+            if all(f(r) for f in self._resource_filters):
+                yield r
 
     def resource(self, manifest, source=None):
         from kubernetes import client
@@ -284,6 +428,15 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         k8s = context.k8s
 
         self._validate_resources()
+        self._compute_project_scope()
+
+        if "project" in context.globals:
+            if self._project_ensure_state_namespace():
+                self._project_acquire_lease()
+                self._project_start_renewal()
+                self._project_read_prior_state()
+                self._project_write_pre_apply()
+                self._project_check_renewal()
 
         cmd = context.app.args.command
         file_name = context.app.args.file
@@ -366,6 +519,24 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         else:
             self._summary = total_created, total_patched, total_deleted
 
+    def handle_cleanup(self):
+        if "project" not in self.context.globals:
+            return
+        if self._project_prior_state is None:
+            # handle_apply short-circuited (dry-run against missing namespace).
+            return
+        self._project_check_renewal()
+        # A raise from _project_delete_obsolete keeps finalized=false so the
+        # next run's conservative union re-considers the not-yet-deleted keys.
+        self._project_delete_obsolete()
+        self._project_write_finalize()
+
+    def handle_shutdown(self):
+        try:
+            self._project_stop_renewal()
+        finally:
+            self._project_release_lease()
+
     def handle_summary(self):
         total_created, total_patched, total_deleted = self._summary
         logger.info("Created %d, patched %d, deleted %d resources", total_created, total_patched, total_deleted)
@@ -408,12 +579,558 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         if patcher not in self._manifest_patchers:
             self._manifest_patchers.append(patcher)
 
+    def api_add_resource_filter(self, pred):
+        if pred not in self._resource_filters:
+            self._resource_filters.append(pred)
+
+    def api_remove_resource_filter(self, pred):
+        if pred in self._resource_filters:
+            self._resource_filters.remove(pred)
+
+    def _project_annotation_patcher(self, manifest, resource_description):
+        """Stamp every manifest with its ``kubernator.io/project`` annotation.
+        No-op when the project plugin has not been registered."""
+        if "project" not in self.context.globals:
+            return manifest
+        project = self.context.app.project
+        if project is None:
+            raise RuntimeError(
+                "%s: project plugin active but no project set in this context" %
+                (resource_description,))
+        metadata = manifest.setdefault("metadata", {})
+        annotations = metadata.setdefault("annotations", {})
+        annotations[PROJECT_ANNOTATION] = project
+        return manifest
+
+    def _project_resource_filter(self, resource):
+        """Scope resources by the cached ``in_scope`` set derived from
+        ``-I``/``-X``. No-op when the project plugin is not active or when
+        neither flag was supplied."""
+        if self._in_scope_projects is None:
+            return True
+        return resource.project in self._in_scope_projects
+
+    def _known_projects(self):
+        """Projects present on currently-loaded manifests. Commit 8 extends
+        this with prior projects recovered from the state Secret."""
+        return {r.project for r in self.resources.values() if r.project}
+
+    def _compute_project_scope(self):
+        """Populate ``self._in_scope_projects`` — called once per apply run.
+
+        * switch off → ``None`` (filter is a no-op).
+        * no ``-I`` / ``-X`` given → ``None`` (every sub-project is in scope
+          implicitly; annotation patcher still stamps, but no filtering).
+        * otherwise, compute the in-scope set against ``known_projects``,
+          validating that every pattern matches at least one known project.
+        """
+        self._in_scope_projects = None
+        if "project" not in self.context.globals:
+            return
+        args = self.context.app.args
+        includes = list(args.include_project or [])
+        excludes = list(args.exclude_project or [])
+        if not includes and not excludes:
+            return
+
+        known = self._known_projects()
+
+        def _unmatched(patterns, flag):
+            bad = [p for p in patterns
+                   if not any(_project_matches(k, p) for k in known)]
+            if bad:
+                return ("%s values match no known project: %s (known: %s)"
+                        % (flag, sorted(bad), sorted(known)))
+            return None
+
+        errs = [m for m in (_unmatched(includes, "-I/--include-project"),
+                            _unmatched(excludes, "-X/--exclude-project"))
+                if m]
+        if errs:
+            raise RuntimeError("; ".join(errs))
+
+        if includes:
+            candidates = {p for p in known
+                          if any(_project_matches(p, i) for i in includes)}
+        else:
+            candidates = set(known)
+        self._in_scope_projects = {p for p in candidates
+                                   if not any(_project_matches(p, x) for x in excludes)}
+
+    def _project_config(self):
+        return self.context.globals.project
+
+    def _project_root(self) -> str:
+        return self._project_config().root
+
+    def _project_state_namespace(self) -> str:
+        return self._project_config().state_namespace
+
+    def _project_cleanup_enabled(self) -> bool:
+        return bool(self._project_config().cleanup)
+
+    def _core_api(self):
+        from kubernetes import client as k8s_client_module
+        return k8s_client_module.CoreV1Api(self.context.k8s.client)
+
+    def _coord_api(self):
+        from kubernetes import client as k8s_client_module
+        return k8s_client_module.CoordinationV1Api(self.context.k8s.client)
+
+    def _dry_run_arg(self):
+        return "All" if self.context.app.args.dry_run else None
+
+    @_pretty_api_exc
+    def _project_ensure_state_namespace(self) -> bool:
+        """Ensure ``state_namespace`` exists. Return True if subsequent state
+        operations (Lease, Secret) can proceed; return False on a dry-run
+        invocation against a missing namespace — server-side dry-run would
+        accept the namespace CREATE but not actually create it, causing every
+        dependent in-namespace call to 404 confusingly.
+        """
+        from kubernetes import client as k8s_client_module
+        from kubernetes.client.rest import ApiException
+
+        ns = self._project_state_namespace()
+        core = self._core_api()
+        try:
+            core.read_namespace(name=ns)
+            return True
+        except ApiException as e:
+            if e.status != 404:
+                raise
+        if self.context.app.args.dry_run:
+            logger.info(
+                "State namespace %s does not exist; it would be created on a "
+                "committed run. Skipping dry-run for Lease and state Secret to "
+                "avoid a confusing validation cascade.", ns)
+            return False
+        logger.info("Creating state namespace %s", ns)
+        body = k8s_client_module.V1Namespace(
+            metadata=k8s_client_module.V1ObjectMeta(name=ns))
+        try:
+            core.create_namespace(body=body)
+        except ApiException as e:
+            if e.status == 409:
+                return True  # Raced; already exists
+            raise
+        return True
+
+    @_pretty_api_exc
+    def _project_acquire_lease(self):
+        """Acquire a per-root Lease in ``state_namespace``. Fail fast on a
+        live lease; take over a stale one using resourceVersion precondition.
+        """
+        from kubernetes import client as k8s_client_module
+        from kubernetes.client.rest import ApiException
+
+        if self.context.app.args.dry_run:
+            logger.info("Skipping Lease acquisition in dry-run mode")
+            return
+
+        self._project_lease_identity = _lease_identity()
+        lease_name = _lease_name(self._project_root())
+        ns = self._project_state_namespace()
+        coord = self._coord_api()
+
+        for _ in range(PROJECT_LEASE_ACQUIRE_ATTEMPTS):
+            try:
+                current = coord.read_namespaced_lease(name=lease_name, namespace=ns)
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+                current = None
+
+            now = datetime.now(timezone.utc)
+            if current is None:
+                body = k8s_client_module.V1Lease(
+                    metadata=k8s_client_module.V1ObjectMeta(name=lease_name, namespace=ns),
+                    spec=k8s_client_module.V1LeaseSpec(
+                        holder_identity=self._project_lease_identity,
+                        lease_duration_seconds=PROJECT_LEASE_DURATION_SECONDS,
+                        acquire_time=now,
+                        renew_time=now,
+                    ),
+                )
+                try:
+                    coord.create_namespaced_lease(namespace=ns, body=body)
+                except ApiException as e:
+                    if e.status == 409:
+                        continue  # Raced — re-read next iteration
+                    raise
+                self._project_lease_acquired = True
+                logger.info("Acquired project Lease %s in %s as %s",
+                            lease_name, ns, self._project_lease_identity)
+                return
+
+            spec = current.spec
+            holder = spec.holder_identity or "<unknown>"
+            duration = spec.lease_duration_seconds or PROJECT_LEASE_DURATION_SECONDS
+            renew = spec.renew_time or spec.acquire_time
+            if renew is not None and renew.tzinfo is None:
+                renew = renew.replace(tzinfo=timezone.utc)
+            expiry = (renew + timedelta(seconds=duration)) if renew else now
+            if expiry >= now:
+                raise RuntimeError(
+                    "Lease %s in %s is held by %r (expires %s); "
+                    "another kubernator run is active. Retry later."
+                    % (lease_name, ns, holder, expiry.isoformat()))
+            logger.warning("Lease %s is stale (holder=%r, expired at %s); taking over",
+                           lease_name, holder, expiry.isoformat())
+            current.spec.holder_identity = self._project_lease_identity
+            current.spec.lease_duration_seconds = PROJECT_LEASE_DURATION_SECONDS
+            current.spec.acquire_time = now
+            current.spec.renew_time = now
+            try:
+                coord.replace_namespaced_lease(
+                    name=lease_name, namespace=ns, body=current)
+                self._project_lease_acquired = True
+                logger.info("Took over stale Lease %s in %s as %s",
+                            lease_name, ns, self._project_lease_identity)
+                return
+            except ApiException as e:
+                if e.status == 409:
+                    continue  # resourceVersion precondition failed — retry
+                raise
+        raise RuntimeError(
+            "Failed to acquire Lease %s in %s after %d attempts"
+            % (lease_name, ns, PROJECT_LEASE_ACQUIRE_ATTEMPTS))
+
+    def _project_renew_loop(self):
+        """Greenlet body: every ``RENEW_INTERVAL_SECONDS``, bump the Lease's
+        renewTime. On any failure mode that indicates lost ownership, sets
+        ``_project_lease_abort`` so the main greenlet can notice."""
+        from kubernetes.client.rest import ApiException
+
+        lease_name = _lease_name(self._project_root())
+        ns = self._project_state_namespace()
+        coord = self._coord_api()
+
+        while True:
+            gevent.sleep(PROJECT_LEASE_RENEW_INTERVAL_SECONDS)
+            try:
+                current = coord.read_namespaced_lease(name=lease_name, namespace=ns)
+            except ApiException as e:
+                api_exc_normalize_body(e)
+                api_exc_format_body(e)
+                logger.error("Lease %s renewal read failed: %s", lease_name, e)
+                self._project_lease_abort = True
+                return
+            if (current.spec.holder_identity or "") != self._project_lease_identity:
+                logger.error("Lease %s identity mismatch (expected %r, got %r); aborting",
+                             lease_name, self._project_lease_identity,
+                             current.spec.holder_identity)
+                self._project_lease_abort = True
+                return
+            current.spec.renew_time = datetime.now(timezone.utc)
+            try:
+                coord.replace_namespaced_lease(
+                    name=lease_name, namespace=ns, body=current)
+                logger.debug("Renewed Lease %s", lease_name)
+            except ApiException as e:
+                api_exc_normalize_body(e)
+                api_exc_format_body(e)
+                logger.error("Lease %s renewal replace failed (%s); aborting", lease_name, e)
+                self._project_lease_abort = True
+                return
+
+    def _project_start_renewal(self):
+        if not self._project_lease_acquired:
+            return
+        self._project_lease_renewer = gevent.spawn(self._project_renew_loop)
+
+    def _project_stop_renewal(self):
+        g = self._project_lease_renewer
+        self._project_lease_renewer = None
+        if g is not None and not g.dead:
+            g.kill(block=False)
+
+    def _project_release_lease(self):
+        from kubernetes.client.rest import ApiException
+
+        if not self._project_lease_acquired:
+            return
+        lease_name = _lease_name(self._project_root())
+        ns = self._project_state_namespace()
+        coord = self._coord_api()
+        try:
+            coord.delete_namespaced_lease(name=lease_name, namespace=ns)
+            logger.info("Released project Lease %s", lease_name)
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug("Lease %s already gone on release", lease_name)
+            else:
+                api_exc_normalize_body(e)
+                api_exc_format_body(e)
+                logger.warning("Failed to delete Lease %s: %s", lease_name, e)
+        finally:
+            self._project_lease_acquired = False
+
+    def _project_check_renewal(self):
+        if self._project_lease_abort:
+            raise RuntimeError(
+                "Project Lease was lost during run (renewal failure). Aborting to "
+                "avoid clobbering another run's state.")
+
+    # --- State Secret I/O --------------------------------------------------
+
+    @_pretty_api_exc
+    def _project_read_prior_state(self):
+        from kubernetes.client.rest import ApiException
+
+        ns = self._project_state_namespace()
+        root = self._project_root()
+        name = _state_secret_name(root)
+        core = self._core_api()
+        try:
+            secret = core.read_namespaced_secret(name=name, namespace=ns)
+        except ApiException as e:
+            if e.status != 404:
+                raise
+            logger.info("No prior project state Secret %s — baseline will be recorded this run", name)
+            self._project_prior_state = _empty_state_payload()
+            self._project_state_rv = None
+            return
+        self._project_state_rv = secret.metadata.resource_version
+        data = secret.data or {}
+        encoded = data.get(PROJECT_STATE_SECRET_DATA_KEY)
+        if not encoded:
+            logger.warning("Project state Secret %s is missing key %r — treating as baseline",
+                           name, PROJECT_STATE_SECRET_DATA_KEY)
+            self._project_prior_state = _empty_state_payload()
+            return
+        try:
+            payload = _decode_state(encoded)
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to decode project state Secret %s: %s" % (name, e)) from e
+        if payload.get(_STATE_VERSION) != PROJECT_STATE_VERSION:
+            raise RuntimeError(
+                "Project state Secret %s has unsupported version %r (expected %r)"
+                % (name, payload.get(_STATE_VERSION), PROJECT_STATE_VERSION))
+        if not payload.get(_STATE_FINALIZED, True):
+            logger.warning(
+                "Project state Secret %s was not finalized by the previous run "
+                "(pending=%s). The prior run may have crashed; cleanup will "
+                "conservatively consider both resources and pending.",
+                name, sorted(payload.get(_STATE_PENDING, {}).keys()))
+        self._project_prior_state = payload
+
+    def _project_compute_new_intent(self):
+        """Group current in-scope resources by project, as sorted ident lists.
+
+        Returns a dict mapping sub-project name → sorted list of ident dicts,
+        plus the set of currently-annotated projects (for cleanup diff)."""
+        current = {}
+        for r in self.resources.values():
+            p = r.project
+            if not p:
+                continue
+            current.setdefault(p, []).append(_resource_ident(r))
+        # Apply scope filter (if active) to restrict what gets recorded.
+        if self._in_scope_projects is not None:
+            current = {p: v for p, v in current.items() if p in self._in_scope_projects}
+        # Sort each project's idents for stable Secret content across runs.
+        for p in current:
+            current[p].sort(key=_ident_key)
+        return current
+
+    def _project_merge_resources(self, prior_resources: dict, new_intent: dict) -> dict:
+        """Return the finalized ``resources`` map: in-scope sub-projects come
+        from ``new_intent``; out-of-scope sub-projects are preserved verbatim."""
+        merged = {
+            p: list(idents) for p, idents in prior_resources.items()
+            if self._in_scope_projects is not None and p not in self._in_scope_projects
+        }
+        for p, idents in new_intent.items():
+            merged[p] = list(idents)
+        return merged
+
+    @_pretty_api_exc
+    def _project_write_state(self, payload: dict):
+        """Create or replace the state Secret. Uses the cached ``resource_version``
+        from the initial read (or prior write) so we don't re-GET every time;
+        falls back to a fresh read on a 409 precondition failure."""
+        from kubernetes import client as k8s_client_module
+        from kubernetes.client.rest import ApiException
+
+        ns = self._project_state_namespace()
+        root = self._project_root()
+        name = _state_secret_name(root)
+        core = self._core_api()
+        encoded = _encode_state(payload)
+        dry_run = self._dry_run_arg()
+        common_kwargs = {"dry_run": dry_run} if dry_run else {}
+
+        def _body(rv):
+            meta = k8s_client_module.V1ObjectMeta(
+                name=name, namespace=ns,
+                annotations={PROJECT_ROOT_ANNOTATION: root})
+            if rv is not None:
+                meta.resource_version = rv
+            return k8s_client_module.V1Secret(
+                metadata=meta,
+                type=PROJECT_STATE_SECRET_TYPE,
+                data={PROJECT_STATE_SECRET_DATA_KEY: encoded},
+            )
+
+        if self._project_state_rv is None:
+            # Prior read returned 404 — create. Handle 409 (raced create) by
+            # falling through to the replace branch.
+            try:
+                resp = core.create_namespaced_secret(
+                    namespace=ns, body=_body(None), **common_kwargs)
+                self._project_state_rv = resp.metadata.resource_version
+                logger.debug("Created project state Secret %s (%d bytes payload)",
+                             name, len(encoded))
+                return
+            except ApiException as e:
+                if e.status != 409:
+                    raise
+                # Re-read to pick up the winner's resourceVersion.
+                existing = core.read_namespaced_secret(name=name, namespace=ns)
+                self._project_state_rv = existing.metadata.resource_version
+
+        try:
+            resp = core.replace_namespaced_secret(
+                name=name, namespace=ns,
+                body=_body(self._project_state_rv),
+                **common_kwargs)
+        except ApiException as e:
+            if e.status != 409:
+                raise
+            # Our cached resourceVersion is stale; re-read once and retry.
+            existing = core.read_namespaced_secret(name=name, namespace=ns)
+            self._project_state_rv = existing.metadata.resource_version
+            resp = core.replace_namespaced_secret(
+                name=name, namespace=ns,
+                body=_body(self._project_state_rv),
+                **common_kwargs)
+        self._project_state_rv = resp.metadata.resource_version
+        logger.debug("Replaced project state Secret %s (%d bytes payload)",
+                     name, len(encoded))
+
+    def _project_write_pre_apply(self):
+        """Phase 1: record ``pending=new_intent`` with ``finalized=false`` while
+        keeping ``resources=prior_resources``. A crash before the Finalize
+        write leaves both visible so the next run's conservative union of
+        ``resources`` and ``pending`` still picks up everything we owned."""
+        self._project_new_intent = self._project_compute_new_intent()
+        payload = {
+            _STATE_VERSION: PROJECT_STATE_VERSION,
+            _STATE_FINALIZED: False,
+            _STATE_RESOURCES: dict(self._project_prior_state.get(_STATE_RESOURCES, {})),
+            _STATE_PENDING: self._project_new_intent,
+        }
+        self._project_write_state(payload)
+
+    def _project_write_finalize(self):
+        prior_resources = self._project_prior_state.get(_STATE_RESOURCES, {})
+        merged_resources = self._project_merge_resources(
+            prior_resources, self._project_new_intent or {})
+        payload = {
+            _STATE_VERSION: PROJECT_STATE_VERSION,
+            _STATE_FINALIZED: True,
+            _STATE_RESOURCES: merged_resources,
+            _STATE_PENDING: {},
+        }
+        self._project_write_state(payload)
+
+    def _project_compute_obsolete(self) -> list:
+        prior_resources = self._project_prior_state.get(_STATE_RESOURCES, {})
+        prior_pending = self._project_prior_state.get(_STATE_PENDING, {})
+        prior_finalized = self._project_prior_state.get(_STATE_FINALIZED, True)
+
+        prior_projects = set(prior_resources.keys())
+        if not prior_finalized:
+            prior_projects |= set(prior_pending.keys())
+
+        current_in_scope_keys = {
+            _ident_key(ident)
+            for idents in (self._project_new_intent or {}).values()
+            for ident in idents
+        }
+
+        prior_in_scope_keys = {}
+        for p in prior_projects:
+            if self._in_scope_projects is not None and p not in self._in_scope_projects:
+                continue
+            for ident in prior_resources.get(p, []):
+                prior_in_scope_keys[_ident_key(ident)] = ident
+            if not prior_finalized:
+                for ident in prior_pending.get(p, []):
+                    prior_in_scope_keys.setdefault(_ident_key(ident), ident)
+
+        to_delete = [ident for key, ident in prior_in_scope_keys.items()
+                     if key not in current_in_scope_keys]
+        to_delete.sort(key=_ident_key)
+        return to_delete
+
+    def _project_delete_obsolete(self):
+        """Delete the resources that used to be ours but are no longer in
+        scope. Accumulates errors — the run fails after best-effort deletion
+        so the Finalize write is skipped and the next run retries."""
+        from kubernetes.client.rest import ApiException
+
+        to_delete = self._project_compute_obsolete()
+        if not to_delete:
+            return
+        dry_run = self.context.app.args.dry_run
+        cleanup_enabled = self._project_cleanup_enabled()
+        if not cleanup_enabled:
+            preview = ["%s/%s/%s%s" % (i.get("group") or "core",
+                                       i["kind"], i["name"],
+                                       "." + i["namespace"] if i.get("namespace") else "")
+                       for i in to_delete]
+            logger.info(
+                "Project cleanup is disabled — %d obsolete resource(s) would be deleted "
+                "if cleanup=True: %s",
+                len(to_delete), preview)
+            return
+
+        failures = []
+        for ident in to_delete:
+            group = ident.get("group") or ""
+            version = ident.get("version") or "v1"
+            api_version = "%s/%s" % (group, version) if group else version
+            manifest = {
+                "apiVersion": api_version,
+                "kind": ident["kind"],
+                "metadata": {"name": ident["name"]},
+            }
+            if ident.get("namespace"):
+                manifest["metadata"]["namespace"] = ident["namespace"]
+            try:
+                res = self.resource(manifest)
+            except Exception as e:
+                logger.critical("Cannot resolve resource for cleanup %s: %s", ident, e)
+                failures.append((ident, e))
+                continue
+            try:
+                logger.info("Cleanup: deleting obsolete resource %s%s",
+                            res, " (dry run)" if dry_run else "")
+                res.delete(dry_run=dry_run, wait=False)
+            except ApiException as e:
+                if e.status == 404:
+                    logger.debug("Cleanup: %s already gone", res)
+                    continue
+                # res.delete is decorated with _normalize_api_exc upstream —
+                # body is already parsed; re-format for pretty output.
+                api_exc_format_body(e)
+                logger.critical("Cleanup: failed to delete %s: %s", res, e)
+                failures.append((ident, e))
+        if failures:
+            raise RuntimeError(
+                "Project cleanup failed to delete %d resource(s); see CRITICAL log lines "
+                "above. Secret left with finalized=false — next run will retry." %
+                (len(failures),))
+
     def api_remove_transformer(self, transformer):
         if transformer in self._transformers:
             self._transformers.remove(transformer)
 
     def api_remove_validator(self, validator):
-        if validator not in self._validators:
+        if validator in self._validators:
             self._validators.remove(validator)
 
     def api_validation_error(self, msg, *args):

--- a/src/main/python/kubernator/plugins/k8s_api.py
+++ b/src/main/python/kubernator/plugins/k8s_api.py
@@ -76,6 +76,8 @@ LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE = re.compile(r"([a-z0-9])([A-Z])")
 CLUSTER_RESOURCE_PATH = re.compile(r"^/apis?/(?:[^/]+/){1,2}([^/]+)$")
 NAMESPACED_RESOURCE_PATH = re.compile(r"^/apis?/(?:[^/]+/){1,2}namespaces/[^/]+/([^/]+)$")
 
+PROJECT_ANNOTATION = "kubernator.io/project"
+
 
 class K8SResourcePatchType(Enum):
     JSON_PATCH = auto()
@@ -340,6 +342,12 @@ class K8SResource:
     @property
     def is_crd(self):
         return self.group == "apiextensions.k8s.io" and self.kind == "CustomResourceDefinition"
+
+    @property
+    def project(self) -> Optional[str]:
+        metadata = self.manifest.get("metadata") or {}
+        annotations = metadata.get("annotations") or {}
+        return annotations.get(PROJECT_ANNOTATION)
 
     def __str__(self):
         return f"{self.api_version}/{self.kind}/{self.name}{'.' + self.namespace if self.namespace else ''}"

--- a/src/main/python/kubernator/plugins/project.py
+++ b/src/main/python/kubernator/plugins/project.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import logging
+
+from kubernator.api import KubernatorPlugin
+
+logger = logging.getLogger("kubernator.project")
+
+
+class ProjectPlugin(KubernatorPlugin):
+    """Switch that activates project scoping, tagging, and cleanup inside the
+    k8s plugin. All behavior lives in the k8s plugin; this plugin just flips
+    the switch by populating ``globals.project``."""
+
+    _name = "project"
+
+    def __init__(self):
+        self.context = None
+
+    def set_context(self, context):
+        self.context = context
+
+    def register(self, *, name, cleanup=False, state_namespace="kubernator-system"):
+        context = self.context
+
+        if "k8s" in context.globals:
+            k8s_plugin = context.globals.k8s._k8s
+            if k8s_plugin.resources:
+                raise RuntimeError(
+                    "project plugin must be registered before any k8s "
+                    "resources are added (k8s.resources is non-empty — "
+                    "register the project plugin in the pre-start script or "
+                    "at the very top of the root .kubernator.py)")
+
+        context.app.project = name
+        # Root = first segment of the composed path at this context. For a
+        # registration nested under a context that already carries a
+        # segment, the parent's segment is the root, not ``name``.
+        root = context.app.project.split(".", 1)[0]
+        context.globals.project = dict(
+            root=root,
+            cleanup=cleanup,
+            state_namespace=state_namespace,
+        )
+        logger.info("Project plugin registered with root project %r "
+                    "(cleanup=%s, state_namespace=%r)",
+                    name, cleanup, state_namespace)
+
+    def __repr__(self):
+        return "Project Plugin"

--- a/src/unittest/python/context_property_tests.py
+++ b/src/unittest/python/context_property_tests.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+from kubernator.api import ContextProperty, PropertyDict, config_parent
+
+
+def _make_segment_descriptor():
+    """Composes dot-joined string segments across the parent chain. Stored at
+    the top-of-chain ``descriptor_host`` PropertyDict under the name ``seg``;
+    plain string segments live at descendants under the same name."""
+
+    def get_segments(origin):
+        segs = []
+        cur = origin
+        while cur is not None:
+            v = cur._PropertyDict__dict.get("seg")
+            if isinstance(v, str):
+                segs.insert(0, v)
+            cur = config_parent(cur)
+        return ".".join(segs) if segs else None
+
+    def set_segment(origin, value):
+        if not isinstance(value, str) or "." in value:
+            raise ValueError("invalid segment %r" % (value,))
+        local = origin._PropertyDict__dict
+        existing = local.get("seg")
+        if isinstance(existing, ContextProperty):
+            raise RuntimeError("refusing to overwrite descriptor at its own layer")
+        if isinstance(existing, str):
+            raise ValueError("already set to %r in this context" % (existing,))
+        local["seg"] = value
+
+    return ContextProperty(get_segments, set_segment)
+
+
+def _install_host():
+    """Return (host, child): host holds the descriptor, child is the first
+    writable layer beneath it."""
+    host = PropertyDict()
+    host.seg = _make_segment_descriptor()
+    child = PropertyDict(_parent=host)
+    return host, child
+
+
+class ContextPropertyTestcase(unittest.TestCase):
+    def test_install_stores_descriptor_as_value(self):
+        host, _ = _install_host()
+        self.assertIsInstance(host._PropertyDict__dict["seg"], ContextProperty)
+
+    def test_read_with_no_segments_yields_none(self):
+        host, child = _install_host()
+        self.assertIsNone(host.seg)
+        self.assertIsNone(child.seg)
+
+    def test_write_dispatches_to_descriptor_setter(self):
+        host, child = _install_host()
+        grandchild = PropertyDict(_parent=child)
+
+        child.seg = "x"
+        grandchild.seg = "y"
+
+        self.assertEqual(child._PropertyDict__dict["seg"], "x")
+        self.assertEqual(grandchild._PropertyDict__dict["seg"], "y")
+        # Descriptor at host is untouched by segment writes.
+        self.assertIsInstance(host._PropertyDict__dict["seg"], ContextProperty)
+
+    def test_read_composes_segments_across_chain(self):
+        host, child = _install_host()
+        grandchild = PropertyDict(_parent=child)
+        greatgrandchild = PropertyDict(_parent=grandchild)
+
+        child.seg = "x"
+        grandchild.seg = "y"
+        greatgrandchild.seg = "z"
+
+        self.assertEqual(child.seg, "x")
+        self.assertEqual(grandchild.seg, "x.y")
+        self.assertEqual(greatgrandchild.seg, "x.y.z")
+
+    def test_sibling_contexts_are_isolated(self):
+        host, child = _install_host()
+        child.seg = "x"
+        sibling_a = PropertyDict(_parent=child)
+        sibling_b = PropertyDict(_parent=child)
+        sibling_a.seg = "a"
+        sibling_b.seg = "b"
+
+        self.assertEqual(sibling_a.seg, "x.a")
+        self.assertEqual(sibling_b.seg, "x.b")
+
+    def test_single_local_assignment_raises_at_same_layer(self):
+        _, child = _install_host()
+        child.seg = "x"
+        with self.assertRaises(ValueError):
+            child.seg = "y"
+
+    def test_inherited_value_does_not_count_as_local_for_duplicate(self):
+        _, child = _install_host()
+        child.seg = "x"
+        grandchild = PropertyDict(_parent=child)
+
+        # Reading yields the inherited composition, but grandchild has no
+        # local segment yet, so the first local assignment is allowed.
+        self.assertEqual(grandchild.seg, "x")
+        grandchild.seg = "y"
+        self.assertEqual(grandchild.seg, "x.y")
+
+        with self.assertRaises(ValueError):
+            grandchild.seg = "z"
+
+    def test_descriptor_invalid_value_rejected(self):
+        _, child = _install_host()
+        with self.assertRaises(ValueError):
+            child.seg = "has.dot"
+        with self.assertRaises(ValueError):
+            child.seg = 42
+
+    def test_read_only_descriptor_rejects_writes(self):
+        host = PropertyDict()
+        host.ro = ContextProperty(lambda origin: "fixed")
+        child = PropertyDict(_parent=host)
+
+        self.assertEqual(host.ro, "fixed")
+        self.assertEqual(child.ro, "fixed")
+        with self.assertRaises(AttributeError):
+            child.ro = "something"
+
+    def test_descriptor_takes_priority_over_raw_local_value(self):
+        _, child = _install_host()
+        child.seg = "x"
+        grandchild = PropertyDict(_parent=child)
+        # Manually stash a non-string local value at grandchild, then verify
+        # the descriptor still drives reads (ignoring the non-string).
+        grandchild._PropertyDict__dict["seg"] = 99
+
+        self.assertEqual(grandchild.seg, "x")
+
+    def test_non_descriptor_attribute_retains_legacy_semantics(self):
+        root = PropertyDict()
+        root.value = 1
+        child = PropertyDict(_parent=root)
+        self.assertEqual(child.value, 1)
+
+        child._PropertyDict__dict["value"] = 2
+        self.assertEqual(child.value, 2)
+        self.assertEqual(root.value, 1)
+
+    def test_set_without_descriptor_falls_through_to_local_storage(self):
+        root = PropertyDict()
+        child = PropertyDict(_parent=root)
+        child.value = 5
+        self.assertEqual(child._PropertyDict__dict["value"], 5)
+        self.assertNotIn("value", root._PropertyDict__dict)
+
+    def test_dict_values_still_wrapped_when_no_descriptor(self):
+        root = PropertyDict()
+        root.app = {"k": "v"}
+        self.assertIsInstance(root._PropertyDict__dict["app"], PropertyDict)
+        self.assertEqual(root.app.k, "v")
+
+    def test_descriptor_dispatch_through_intermediate_property_dict(self):
+        # Descriptor lives on a sibling attribute chain: mirrors the plan's
+        # ``globals.app.project`` layout where access is ``context.app.project``.
+        globals_ctx = PropertyDict()
+        globals_ctx.globals = globals_ctx
+        globals_ctx.app = {"base": 1}
+        # Install descriptor in the wrapped globals.app PropertyDict.
+        globals_ctx.app.seg = _make_segment_descriptor()
+
+        context = PropertyDict(_parent=globals_ctx)
+        context.app = {}  # child .app chained to globals.app
+        self.assertIsNone(context.app.seg)
+        context.app.seg = "x"
+        self.assertEqual(context.app.seg, "x")
+
+        subdir = PropertyDict(_parent=context)
+        subdir.app = {}  # per-subdir .app chained to context.app
+        subdir.app.seg = "y"
+        self.assertEqual(subdir.app.seg, "x.y")
+        # Sibling subdir sees only its own segment plus the parent's.
+        sibling = PropertyDict(_parent=context)
+        sibling.app = {}
+        sibling.app.seg = "z"
+        self.assertEqual(sibling.app.seg, "x.z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/dispatch_tests.py
+++ b/src/unittest/python/dispatch_tests.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from pathlib import Path
+
+from kubernator.api import KubernatorPlugin, PropertyDict
+
+
+class StubPlugin(KubernatorPlugin):
+    _name = "stub"
+
+    def __init__(self, name):
+        self._name = name
+        self.context = None
+        self.handler_calls = []
+
+    def set_context(self, context):
+        self.context = context
+
+    def handle_after_dir(self, cwd):
+        self.handler_calls.append(("after_dir", cwd))
+
+
+class CrossPluginCallPlugin(KubernatorPlugin):
+    """Plugin that calls into another plugin's method during its handler,
+    simulating the template→k8s cross-plugin reentry pattern."""
+    _name = "caller"
+
+    def __init__(self, target):
+        self._target = target
+        self.context = None
+        self.target_context_was_set = None
+
+    def set_context(self, context):
+        self.context = context
+
+    def handle_after_dir(self, cwd):
+        self.target_context_was_set = self._target.context is not None
+
+
+class DispatchToAllPluginsTests(unittest.TestCase):
+    def test_all_plugins_have_context_during_handler(self):
+        """All plugins must have their context set while any handler in the
+        same phase is executing — not just the one currently being called."""
+        ctx = PropertyDict()
+        target = StubPlugin("target")
+        caller = CrossPluginCallPlugin(target)
+        ctx._plugins = [target, caller]
+
+        from kubernator.app import App
+        app = App.__new__(App)
+        app.context = ctx
+
+        def run(h):
+            h_f = getattr(h, "handle_after_dir", None)
+            if h_f:
+                h_f(Path("/dummy"))
+
+        app._dispatch_to_all_plugins(True, ctx, run)
+
+        self.assertTrue(caller.target_context_was_set,
+                        "target plugin's context was None during caller's handler "
+                        "(cross-plugin reentry broken)")
+
+    def test_contexts_cleared_after_phase(self):
+        ctx = PropertyDict()
+        p1 = StubPlugin("p1")
+        p2 = StubPlugin("p2")
+        ctx._plugins = [p1, p2]
+
+        from kubernator.app import App
+        app = App.__new__(App)
+        app.context = ctx
+
+        app._dispatch_to_all_plugins(False, ctx, lambda h: None)
+
+        self.assertIsNone(p1.context)
+        self.assertIsNone(p2.context)
+
+    def test_contexts_cleared_even_on_exception(self):
+        ctx = PropertyDict()
+        p1 = StubPlugin("p1")
+        p2 = StubPlugin("p2")
+        ctx._plugins = [p1, p2]
+
+        from kubernator.app import App
+        app = App.__new__(App)
+        app.context = ctx
+
+        def exploding_run(h):
+            if h._name == "p2":
+                raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            app._dispatch_to_all_plugins(False, ctx, exploding_run)
+
+        self.assertIsNone(p1.context)
+        self.assertIsNone(p2.context)
+
+    def test_reverse_order_respected(self):
+        ctx = PropertyDict()
+        call_order = []
+        p1 = StubPlugin("p1")
+        p2 = StubPlugin("p2")
+        ctx._plugins = [p1, p2]
+
+        from kubernator.app import App
+        app = App.__new__(App)
+        app.context = ctx
+
+        def tracking_run(h):
+            call_order.append(h._name)
+
+        app._dispatch_to_all_plugins(True, ctx, tracking_run)
+        self.assertEqual(call_order, ["p2", "p1"])
+
+        call_order.clear()
+        app._dispatch_to_all_plugins(False, ctx, tracking_run)
+        self.assertEqual(call_order, ["p1", "p2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_project_tests.py
+++ b/src/unittest/python/k8s_project_tests.py
@@ -1,0 +1,596 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from types import SimpleNamespace
+
+from kubernator.plugins.k8s import (KubernetesPlugin,
+                                    _encode_state, _decode_state,
+                                    _project_matches,
+                                    _resource_ident, _ident_key,
+                                    _state_secret_name, _lease_name,
+                                    PROJECT_STATE_VERSION)
+from kubernator.plugins.k8s_api import K8SResourceKey
+
+
+def _fake_resource(group, version, kind, name, namespace, project):
+    return SimpleNamespace(
+        key=K8SResourceKey(group, kind, name, namespace),
+        rdef=SimpleNamespace(version=version),
+        group=group, version=version, kind=kind, name=name, namespace=namespace,
+        project=project,
+    )
+
+
+def _ident(kind, name, namespace="default", group="", version="v1"):
+    return {"group": group, "version": version, "kind": kind,
+            "name": name, "namespace": namespace}
+
+
+class PayloadCodecTests(unittest.TestCase):
+    def test_encode_decode_roundtrip(self):
+        payload = {
+            "version": "1",
+            "finalized": True,
+            "resources": {
+                "alpha": [
+                    {"group": "", "version": "v1", "kind": "ConfigMap",
+                     "namespace": "default", "name": "cm-a"},
+                    {"group": "apps", "version": "v1", "kind": "Deployment",
+                     "namespace": "default", "name": "dep-a"},
+                ],
+                "alpha.beta": [
+                    {"group": "", "version": "v1", "kind": "Service",
+                     "namespace": "prod", "name": "svc-b"},
+                    {"group": "", "version": "v1", "kind": "Service",
+                     "namespace": "prod", "name": "svc-c"},
+                ],
+            },
+            "pending": {},
+        }
+        encoded = _encode_state(payload)
+        self.assertIsInstance(encoded, str)
+        self.assertGreater(len(encoded), 0)
+        decoded = _decode_state(encoded)
+        self.assertEqual(decoded, payload)
+
+    def test_encode_stable_across_calls(self):
+        payload = {
+            "version": PROJECT_STATE_VERSION,
+            "finalized": False,
+            "resources": {"a": [], "b": []},
+            "pending": {"c": []},
+        }
+        a = _encode_state(payload)
+        b = _encode_state(payload)
+        self.assertEqual(a, b)
+
+    def test_encode_compresses_repetitive_content(self):
+        # 200 near-identical idents with the same keys; gzip should compress well.
+        entries = [{"group": "apps", "version": "v1", "kind": "Deployment",
+                    "namespace": "default", "name": "dep-%03d" % i}
+                   for i in range(200)]
+        payload = {"version": "1", "finalized": True,
+                   "resources": {"alpha": entries}, "pending": {}}
+        encoded = _encode_state(payload)
+        # Should fit well under Kubernetes 1 MiB Secret cap with large margin.
+        self.assertLess(len(encoded), 10 * 1024)
+
+
+class ProjectMatcherTests(unittest.TestCase):
+    def test_exact_and_prefix_match(self):
+        self.assertTrue(_project_matches("alpha", "alpha"))
+        self.assertTrue(_project_matches("alpha.beta", "alpha"))
+        self.assertTrue(_project_matches("alpha.beta.gamma", "alpha.beta"))
+
+    def test_does_not_match_when_not_prefix(self):
+        self.assertFalse(_project_matches("alpha", "alphabet"))
+        self.assertFalse(_project_matches("alphabet", "alpha"))
+        self.assertFalse(_project_matches("beta", "alpha"))
+
+
+class ResourceIdentTests(unittest.TestCase):
+    def test_namespaced_ident(self):
+        r = _fake_resource("apps", "v1", "Deployment", "d1", "ns1", "alpha")
+        ident = _resource_ident(r)
+        self.assertEqual(ident, {"group": "apps", "version": "v1",
+                                 "kind": "Deployment", "name": "d1",
+                                 "namespace": "ns1"})
+
+    def test_cluster_scoped_ident_omits_namespace(self):
+        r = _fake_resource("", "v1", "Namespace", "alpha-ns", None, "alpha")
+        ident = _resource_ident(r)
+        self.assertNotIn("namespace", ident)
+        self.assertEqual(ident["kind"], "Namespace")
+
+    def test_ident_key_is_hashable_and_matches_across_instances(self):
+        r1 = _fake_resource("apps", "v1", "Deployment", "d1", "ns1", "alpha")
+        r2 = _fake_resource("apps", "v1", "Deployment", "d1", "ns1", "alpha.beta")
+        self.assertEqual(_ident_key(_resource_ident(r1)),
+                         _ident_key(_resource_ident(r2)))
+
+
+class NamingTests(unittest.TestCase):
+    def test_names_are_deterministic(self):
+        self.assertEqual(_state_secret_name("alpha"), _state_secret_name("alpha"))
+        self.assertEqual(_lease_name("alpha"), _lease_name("alpha"))
+
+    def test_names_differ_between_roots(self):
+        self.assertNotEqual(_state_secret_name("alpha"), _state_secret_name("beta"))
+        self.assertNotEqual(_lease_name("alpha"), _lease_name("beta"))
+
+    def test_name_length_within_k8s_limits(self):
+        # sha1 truncated to 12 chars → plenty of headroom under 253-char DNS limit.
+        self.assertLessEqual(len(_state_secret_name("alpha")), 253)
+        self.assertLessEqual(len(_lease_name("alpha")), 253)
+
+
+def _make_plugin(project_switch=True, include=(), exclude=(),
+                 cleanup=False, in_scope=None):
+    """Construct a real ``KubernetesPlugin`` with a fake context so pure-logic
+    methods can be exercised without touching a cluster."""
+    plugin = KubernetesPlugin.__new__(KubernetesPlugin)
+    plugin._resource_filters = []
+    plugin._manifest_patchers = []
+    plugin._in_scope_projects = set(in_scope) if in_scope is not None else None
+    plugin._project_prior_state = None
+    plugin._project_new_intent = None
+    plugin.resources = {}
+
+    args = SimpleNamespace(include_project=list(include),
+                           exclude_project=list(exclude),
+                           dry_run=False,
+                           command="apply")
+    app_ctx = SimpleNamespace(args=args, project=None)
+    globals_entries = {}
+    if project_switch:
+        globals_entries["project"] = SimpleNamespace(
+            root="alpha", cleanup=cleanup, state_namespace="kubernator-system")
+
+    class _GlobalsShim:
+        def __contains__(self, k):
+            return k in globals_entries
+
+        def __getattr__(self, k):
+            try:
+                return globals_entries[k]
+            except KeyError as e:
+                raise AttributeError(k) from e
+
+    plugin.context = SimpleNamespace(globals=_GlobalsShim(), app=app_ctx, k8s=None)
+    return plugin
+
+
+class ScopeComputationTests(unittest.TestCase):
+    def _known(self, plugin, projects):
+        plugin.resources = {
+            ("k", i): _fake_resource("", "v1", "ConfigMap", "cm-%d" % i, "default", p)
+            for i, p in enumerate(projects)
+        }
+
+    def test_no_flags_scope_is_none(self):
+        plugin = _make_plugin(project_switch=True)
+        self._known(plugin, ["alpha", "alpha.beta", "alpha.gamma"])
+        plugin._compute_project_scope()
+        self.assertIsNone(plugin._in_scope_projects)
+
+    def test_switch_off_scope_is_none(self):
+        plugin = _make_plugin(project_switch=False, include=["alpha"])
+        plugin._compute_project_scope()
+        self.assertIsNone(plugin._in_scope_projects)
+
+    def test_include_prefix_match(self):
+        plugin = _make_plugin(include=["alpha.beta"])
+        self._known(plugin, ["alpha", "alpha.beta", "alpha.beta.x", "alpha.gamma"])
+        plugin._compute_project_scope()
+        self.assertEqual(plugin._in_scope_projects,
+                         {"alpha.beta", "alpha.beta.x"})
+
+    def test_exclude_subtracts_from_includes(self):
+        plugin = _make_plugin(include=["alpha"], exclude=["alpha.beta"])
+        self._known(plugin, ["alpha", "alpha.beta", "alpha.beta.x", "alpha.gamma"])
+        plugin._compute_project_scope()
+        self.assertEqual(plugin._in_scope_projects,
+                         {"alpha", "alpha.gamma"})
+
+    def test_exclude_without_includes_uses_all_known(self):
+        plugin = _make_plugin(exclude=["alpha.beta"])
+        self._known(plugin, ["alpha", "alpha.beta", "alpha.gamma"])
+        plugin._compute_project_scope()
+        self.assertEqual(plugin._in_scope_projects,
+                         {"alpha", "alpha.gamma"})
+
+    def test_unmatched_include_pattern_fatal(self):
+        plugin = _make_plugin(include=["beta"])
+        self._known(plugin, ["alpha", "alpha.beta"])
+        with self.assertRaises(RuntimeError) as exc:
+            plugin._compute_project_scope()
+        self.assertIn("-I", str(exc.exception))
+
+    def test_unmatched_exclude_pattern_fatal(self):
+        plugin = _make_plugin(exclude=["delta"])
+        self._known(plugin, ["alpha", "alpha.beta"])
+        with self.assertRaises(RuntimeError) as exc:
+            plugin._compute_project_scope()
+        self.assertIn("-X", str(exc.exception))
+
+
+class ResourceFilterTests(unittest.TestCase):
+    def test_filter_passes_all_when_scope_none(self):
+        plugin = _make_plugin()
+        plugin._in_scope_projects = None
+        a = _fake_resource("", "v1", "ConfigMap", "a", "default", "alpha")
+        b = _fake_resource("", "v1", "ConfigMap", "b", "default", "alpha.beta")
+        self.assertTrue(plugin._project_resource_filter(a))
+        self.assertTrue(plugin._project_resource_filter(b))
+
+    def test_filter_scopes_to_in_scope_set(self):
+        plugin = _make_plugin(in_scope={"alpha.beta", "alpha.beta.x"})
+        matches = _fake_resource("", "v1", "ConfigMap", "b", "default", "alpha.beta")
+        not_match = _fake_resource("", "v1", "ConfigMap", "a", "default", "alpha.gamma")
+        self.assertTrue(plugin._project_resource_filter(matches))
+        self.assertFalse(plugin._project_resource_filter(not_match))
+
+
+class NewIntentComputationTests(unittest.TestCase):
+    def test_groups_in_scope_resources_by_project(self):
+        plugin = _make_plugin(in_scope={"alpha", "alpha.beta"})
+        a1 = _fake_resource("", "v1", "ConfigMap", "a1", "default", "alpha")
+        a2 = _fake_resource("", "v1", "ConfigMap", "a2", "default", "alpha")
+        b1 = _fake_resource("", "v1", "ConfigMap", "b1", "prod", "alpha.beta")
+        g1 = _fake_resource("", "v1", "ConfigMap", "g1", "prod", "alpha.gamma")
+        plugin.resources = {("k", i): r for i, r in enumerate([a1, a2, b1, g1])}
+
+        intent = plugin._project_compute_new_intent()
+        # alpha.gamma is out of scope → not recorded.
+        self.assertEqual(set(intent.keys()), {"alpha", "alpha.beta"})
+        self.assertEqual(len(intent["alpha"]), 2)
+        self.assertEqual(len(intent["alpha.beta"]), 1)
+
+    def test_skips_resources_without_project(self):
+        plugin = _make_plugin(in_scope=None)
+        r_proj = _fake_resource("", "v1", "ConfigMap", "p1", "default", "alpha")
+        r_no_proj = _fake_resource("", "v1", "ConfigMap", "x", "default", None)
+        plugin.resources = {("k", 0): r_proj, ("k", 1): r_no_proj}
+
+        intent = plugin._project_compute_new_intent()
+        self.assertEqual(set(intent.keys()), {"alpha"})
+
+
+class ObsoleteComputationTests(unittest.TestCase):
+    def test_empty_prior_yields_no_deletions(self):
+        plugin = _make_plugin(in_scope=None)
+        plugin._project_prior_state = {"resources": {}, "pending": {},
+                                       "finalized": True}
+        plugin._project_new_intent = {
+            "alpha": [_ident("ConfigMap", "a1"),
+                      _ident("ConfigMap", "a2")]}
+        self.assertEqual(plugin._project_compute_obsolete(), [])
+
+    def test_removed_resource_in_prior_marked_obsolete(self):
+        plugin = _make_plugin(in_scope=None)
+        plugin._project_prior_state = {
+            "resources": {
+                "alpha": [_ident("ConfigMap", "a1"),
+                          _ident("ConfigMap", "a2")]
+            },
+            "pending": {},
+            "finalized": True,
+        }
+        plugin._project_new_intent = {"alpha": [_ident("ConfigMap", "a1")]}
+        obsolete = plugin._project_compute_obsolete()
+        self.assertEqual(len(obsolete), 1)
+        self.assertEqual(obsolete[0]["name"], "a2")
+
+    def test_resource_moved_between_projects_not_deleted(self):
+        plugin = _make_plugin(in_scope=None)
+        # Prior: x under alpha. Current: x under alpha.beta. Same key.
+        plugin._project_prior_state = {
+            "resources": {
+                "alpha": [_ident("ConfigMap", "x")],
+                "alpha.beta": [_ident("ConfigMap", "y")],
+            },
+            "pending": {},
+            "finalized": True,
+        }
+        plugin._project_new_intent = {
+            "alpha": [],
+            "alpha.beta": [_ident("ConfigMap", "x"),
+                           _ident("ConfigMap", "y")],
+        }
+        self.assertEqual(plugin._project_compute_obsolete(), [])
+
+    def test_crashed_prior_uses_conservative_union(self):
+        plugin = _make_plugin(in_scope=None)
+        plugin._project_prior_state = {
+            "resources": {"alpha": [_ident("ConfigMap", "a1")]},
+            "pending": {
+                "alpha": [_ident("ConfigMap", "a2"),
+                          _ident("ConfigMap", "a3")]
+            },
+            "finalized": False,
+        }
+        plugin._project_new_intent = {"alpha": [_ident("ConfigMap", "a1")]}
+        obsolete = plugin._project_compute_obsolete()
+        self.assertEqual(sorted(i["name"] for i in obsolete), ["a2", "a3"])
+
+    def test_out_of_scope_prior_projects_preserved(self):
+        plugin = _make_plugin(in_scope={"alpha.beta"})
+        plugin._project_prior_state = {
+            "resources": {
+                "alpha.beta": [_ident("ConfigMap", "b1"),
+                               _ident("ConfigMap", "b2")],
+                "alpha.gamma": [_ident("ConfigMap", "g1")],
+            },
+            "pending": {},
+            "finalized": True,
+        }
+        plugin._project_new_intent = {
+            "alpha.beta": [_ident("ConfigMap", "b1")]
+        }
+        obsolete = plugin._project_compute_obsolete()
+        # g1 is out of scope (alpha.gamma) — not considered; only b2 is obsolete.
+        self.assertEqual(sorted(i["name"] for i in obsolete), ["b2"])
+
+
+class ResourceMergeTests(unittest.TestCase):
+    def test_merge_overlays_in_scope_and_preserves_out_of_scope(self):
+        plugin = _make_plugin(in_scope={"alpha.beta"})
+        prior = {
+            "alpha.beta": [_ident("ConfigMap", "old1")],
+            "alpha.gamma": [_ident("ConfigMap", "g1")],
+        }
+        new_intent = {
+            "alpha.beta": [_ident("ConfigMap", "new1"),
+                           _ident("ConfigMap", "new2")]
+        }
+        merged = plugin._project_merge_resources(prior, new_intent)
+        self.assertEqual(set(merged.keys()), {"alpha.beta", "alpha.gamma"})
+        self.assertEqual(sorted(i["name"] for i in merged["alpha.beta"]),
+                         ["new1", "new2"])
+        self.assertEqual(merged["alpha.gamma"], [_ident("ConfigMap", "g1")])
+
+    def test_merge_with_no_scope_filter_overlays_everything(self):
+        plugin = _make_plugin(in_scope=None)
+        prior = {
+            "alpha": [_ident("ConfigMap", "a1")],
+            "alpha.beta": [_ident("ConfigMap", "b1")],
+        }
+        new_intent = {"alpha": [_ident("ConfigMap", "a2")]}
+        merged = plugin._project_merge_resources(prior, new_intent)
+        # alpha replaced; alpha.beta absent from new_intent → dropped (it
+        # would be in scope and was overlaid with nothing).
+        self.assertEqual(merged, {"alpha": [_ident("ConfigMap", "a2")]})
+
+
+def _true_pred(r):
+    return True
+
+
+def _false_pred(r):
+    return False
+
+
+def _identity(m):
+    return m
+
+
+def _none(m):
+    return None
+
+
+class AnnotationPatcherTests(unittest.TestCase):
+    def test_stamps_annotation_when_project_active(self):
+        plugin = _make_plugin(project_switch=True)
+        plugin.context.app.project = "alpha.beta"
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                    "metadata": {"name": "cm1"}}
+        result = plugin._project_annotation_patcher(manifest, "test resource")
+        self.assertEqual(
+            result["metadata"]["annotations"]["kubernator.io/project"],
+            "alpha.beta")
+
+    def test_noop_when_project_switch_off(self):
+        plugin = _make_plugin(project_switch=False)
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                    "metadata": {"name": "cm1"}}
+        result = plugin._project_annotation_patcher(manifest, "test resource")
+        self.assertNotIn("annotations", result.get("metadata", {}))
+
+    def test_raises_when_project_active_but_no_segment(self):
+        plugin = _make_plugin(project_switch=True)
+        plugin.context.app.project = None
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap"}
+        with self.assertRaises(RuntimeError) as exc:
+            plugin._project_annotation_patcher(manifest, "test resource desc")
+        self.assertIn("no project set", str(exc.exception))
+
+    def test_creates_metadata_and_annotations_if_absent(self):
+        plugin = _make_plugin(project_switch=True)
+        plugin.context.app.project = "alpha"
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap"}
+        result = plugin._project_annotation_patcher(manifest, "test resource")
+        self.assertEqual(
+            result["metadata"]["annotations"]["kubernator.io/project"],
+            "alpha")
+
+
+class ResourceFilterAPITests(unittest.TestCase):
+    def test_add_remove_resource_filter(self):
+        plugin = _make_plugin()
+        plugin.api_add_resource_filter(_true_pred)
+        plugin.api_add_resource_filter(_false_pred)
+        self.assertIn(_true_pred, plugin._resource_filters)
+        self.assertIn(_false_pred, plugin._resource_filters)
+        plugin.api_remove_resource_filter(_true_pred)
+        self.assertNotIn(_true_pred, plugin._resource_filters)
+        self.assertIn(_false_pred, plugin._resource_filters)
+
+    def test_add_resource_filter_idempotent(self):
+        plugin = _make_plugin()
+        plugin.api_add_resource_filter(_true_pred)
+        plugin.api_add_resource_filter(_true_pred)
+        self.assertEqual(plugin._resource_filters.count(_true_pred), 1)
+
+    def test_remove_nonexistent_resource_filter_is_noop(self):
+        plugin = _make_plugin()
+        plugin.api_remove_resource_filter(_true_pred)
+        self.assertEqual(len(plugin._resource_filters), 0)
+
+
+class TransformerValidatorAPITests(unittest.TestCase):
+    def test_add_remove_transformer(self):
+        plugin = _make_plugin()
+        plugin._transformers = []
+        plugin.api_add_transformer(_identity)
+        plugin.api_add_transformer(_none)
+        self.assertIn(_identity, plugin._transformers)
+        self.assertIn(_none, plugin._transformers)
+        plugin.api_remove_transformer(_identity)
+        self.assertNotIn(_identity, plugin._transformers)
+        self.assertIn(_none, plugin._transformers)
+
+    def test_remove_nonexistent_transformer_is_noop(self):
+        plugin = _make_plugin()
+        plugin._transformers = []
+        plugin.api_remove_transformer(_identity)
+
+    def test_add_remove_validator(self):
+        plugin = _make_plugin()
+        plugin._validators = []
+        plugin.api_add_validator(_identity)
+        plugin.api_add_validator(_none)
+        self.assertIn(_identity, plugin._validators)
+        self.assertIn(_none, plugin._validators)
+        plugin.api_remove_validator(_identity)
+        self.assertNotIn(_identity, plugin._validators)
+        self.assertIn(_none, plugin._validators)
+
+    def test_remove_nonexistent_validator_is_noop(self):
+        plugin = _make_plugin()
+        plugin._validators = []
+        plugin.api_remove_validator(_none)
+
+
+class CleanupDisabledTests(unittest.TestCase):
+    def test_obsolete_resources_skipped_when_cleanup_disabled(self):
+        plugin = _make_plugin(project_switch=True, cleanup=False, in_scope=None)
+        plugin._project_prior_state = {
+            "resources": {
+                "alpha": [_ident("ConfigMap", "old1"),
+                          _ident("ConfigMap", "old2")]
+            },
+            "pending": {},
+            "finalized": True,
+        }
+        plugin._project_new_intent = {"alpha": [_ident("ConfigMap", "old1")]}
+        # Should return without error — no k8s API calls, just logging.
+        plugin._project_delete_obsolete()
+        # Verify the obsolete list was correctly computed (old2 missing from intent).
+        obsolete = plugin._project_compute_obsolete()
+        self.assertEqual(len(obsolete), 1)
+        self.assertEqual(obsolete[0]["name"], "old2")
+
+
+class PrettyApiExcDecoratorTests(unittest.TestCase):
+    def test_passes_through_normal_return(self):
+        from kubernator.plugins.k8s import _pretty_api_exc
+
+        @_pretty_api_exc
+        def ok():
+            return 42
+        self.assertEqual(ok(), 42)
+
+    def test_normalizes_and_reraises_api_exception(self):
+        from kubernator.plugins.k8s import _pretty_api_exc
+        from kubernetes.client.rest import ApiException
+
+        @_pretty_api_exc
+        def boom():
+            raise ApiException(status=409, reason="Conflict")
+
+        with self.assertRaises(ApiException) as ctx:
+            boom()
+        self.assertEqual(ctx.exception.status, 409)
+
+    def test_does_not_catch_non_api_exceptions(self):
+        from kubernator.plugins.k8s import _pretty_api_exc
+
+        @_pretty_api_exc
+        def boom():
+            raise ValueError("not an API exception")
+
+        with self.assertRaises(ValueError):
+            boom()
+
+
+class LeaseLifecycleTests(unittest.TestCase):
+    def test_check_renewal_noop_when_not_aborted(self):
+        plugin = _make_plugin()
+        plugin._project_lease_abort = False
+        plugin._project_check_renewal()
+
+    def test_check_renewal_raises_when_aborted(self):
+        plugin = _make_plugin()
+        plugin._project_lease_abort = True
+        with self.assertRaises(RuntimeError) as ctx:
+            plugin._project_check_renewal()
+        self.assertIn("Lease was lost", str(ctx.exception))
+
+    def test_start_renewal_noop_when_lease_not_acquired(self):
+        plugin = _make_plugin()
+        plugin._project_lease_acquired = False
+        plugin._project_lease_renewer = None
+        plugin._project_start_renewal()
+        self.assertIsNone(plugin._project_lease_renewer)
+
+    def test_stop_renewal_noop_when_no_renewer(self):
+        plugin = _make_plugin()
+        plugin._project_lease_renewer = None
+        plugin._project_stop_renewal()
+        self.assertIsNone(plugin._project_lease_renewer)
+
+
+class HandleCleanupTests(unittest.TestCase):
+    def test_noop_when_project_switch_off(self):
+        plugin = _make_plugin(project_switch=False)
+        plugin._project_prior_state = None
+        plugin.handle_cleanup()
+
+    def test_noop_when_prior_state_is_none(self):
+        plugin = _make_plugin(project_switch=True)
+        plugin._project_prior_state = None
+        plugin.handle_cleanup()
+
+
+class HandleShutdownTests(unittest.TestCase):
+    def test_shutdown_noop_when_nothing_acquired(self):
+        plugin = _make_plugin()
+        plugin._project_lease_acquired = False
+        plugin._project_lease_renewer = None
+        plugin.handle_shutdown()
+        self.assertFalse(plugin._project_lease_acquired)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/project_tests.py
+++ b/src/unittest/python/project_tests.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from kubernator.api import PropertyDict
+from kubernator.app import App
+from kubernator.plugins.project import ProjectPlugin
+
+
+def _make_app_and_contexts(k8s_present=False, k8s_resources=None):
+    """Build an App, run its handle_init to install the project descriptor on
+    globals.app.project, and return (app, globals, dir_ctx). The caller sets
+    ``app.context`` to the dir context it wants to operate on before invoking
+    plugin.register or ``ctx.app.project = ...``.
+    """
+    args = SimpleNamespace(path=Path("."))
+    app = App(args)
+    app.handle_init()
+    g = app._top_level_context._PropertyDict__parent  # global context
+    if k8s_present:
+        k8s_plugin = SimpleNamespace(resources=dict(k8s_resources or {}))
+        g.k8s = dict(_k8s=k8s_plugin)
+    dir_ctx = app._top_dir_context
+    app.context = dir_ctx
+    return app, g, dir_ctx
+
+
+class ProjectPluginRegistrationTests(unittest.TestCase):
+    def test_register_without_k8s_sets_project_and_switch(self):
+        app, g, ctx = _make_app_and_contexts(k8s_present=False)
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        plugin.register(name="alpha")
+
+        self.assertEqual(ctx.app.project, "alpha")
+        self.assertIn("project", g)
+        self.assertEqual(g.project.root, "alpha")
+        self.assertEqual(g.project.cleanup, False)
+        self.assertEqual(g.project.state_namespace, "kubernator-system")
+
+    def test_register_carries_cleanup_and_state_namespace(self):
+        app, g, ctx = _make_app_and_contexts(k8s_present=False)
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        plugin.register(name="alpha", cleanup=True, state_namespace="ops")
+
+        self.assertEqual(g.project.cleanup, True)
+        self.assertEqual(g.project.state_namespace, "ops")
+
+    def test_register_with_k8s_empty_resources_allowed(self):
+        app, g, ctx = _make_app_and_contexts(k8s_present=True, k8s_resources={})
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        plugin.register(name="alpha")
+
+        self.assertEqual(ctx.app.project, "alpha")
+
+    def test_register_fails_when_k8s_has_resources(self):
+        sentinel_a = object()
+        sentinel_b = object()
+        app, g, ctx = _make_app_and_contexts(
+            k8s_present=True,
+            k8s_resources={"cm/a": sentinel_a, "cm/b": sentinel_b})
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        with self.assertRaises(RuntimeError) as exc:
+            plugin.register(name="alpha")
+        self.assertIn("k8s.resources is non-empty", str(exc.exception))
+
+    def test_register_invalid_name_rejected(self):
+        app, _, ctx = _make_app_and_contexts()
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        with self.assertRaises(ValueError):
+            plugin.register(name="bad.name")
+        with self.assertRaises(ValueError):
+            plugin.register(name="has space")
+        with self.assertRaises(ValueError):
+            plugin.register(name="")
+
+    def test_register_second_time_at_same_context_rejects(self):
+        app, _, ctx = _make_app_and_contexts()
+        plugin = ProjectPlugin()
+        plugin.set_context(ctx)
+
+        plugin.register(name="alpha")
+        # Second register() on the same context tries to re-set the project
+        # segment, which the App-owned descriptor rejects.
+        with self.assertRaises(ValueError):
+            plugin.register(name="beta")
+
+    def test_register_in_subcontext_extends_project_name(self):
+        app, _, ctx = _make_app_and_contexts()
+        plugin_root = ProjectPlugin()
+        plugin_root.set_context(ctx)
+        plugin_root.register(name="alpha")
+
+        sub = PropertyDict(_parent=ctx)
+        # Simulate the App advancing to the sub directory.
+        app.context = sub
+        plugin_sub = ProjectPlugin()
+        plugin_sub.set_context(sub)
+        plugin_sub.register(name="beta")
+
+        self.assertEqual(sub.app.project, "alpha.beta")
+
+        app.context = ctx
+        self.assertEqual(ctx.app.project, "alpha")
+
+    def test_sibling_subcontexts_isolated(self):
+        app, _, ctx = _make_app_and_contexts()
+        plugin_root = ProjectPlugin()
+        plugin_root.set_context(ctx)
+        plugin_root.register(name="root")
+
+        sub_a = PropertyDict(_parent=ctx)
+        sub_b = PropertyDict(_parent=ctx)
+        app.context = sub_a
+        sub_a.app.project = "a"
+        app.context = sub_b
+        sub_b.app.project = "b"
+
+        app.context = sub_a
+        self.assertEqual(sub_a.app.project, "root.a")
+        app.context = sub_b
+        self.assertEqual(sub_b.app.project, "root.b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces a **project plugin** that adds hierarchical scope, ownership tracking, and cleanup to Kubernator. Kubernator today is stateless — every run reconciles everything it discovers and cannot tell whether a resource it sees was applied by us, by someone else, or by a previous run that has since dropped the manifest. Project v1 fixes all three:

- **Scope.** A user registers the project plugin once at the root with a name; sub-directories extend the project via ``ktor.app.project = \"<segment>\"`` (dot-joined top-down). CLI flags ``-I``/``-X`` scope a run to specific sub-trees (repeatable, combineable: ``candidates = known ∩ includes`` then ``in_scope = candidates − excludes``).
- **Ownership.** Every applied resource is stamped with a ``kubernator.io/project`` annotation carrying the composed path. A single gzipped JSON Secret per top-level project (``<state_namespace>/kubernator-project-<sha1(root)[:12]>``) records the idents of resources we own.
- **Cleanup.** On each run, the prior Secret's idents are diffed against the current in-scope manifests; when ``cleanup=True``, resources that used to be ours but are no longer in scope get deleted. Resources that moved between sub-projects within the run's in-scope set are detected and preserved (dedup on identity, ignoring project).

### Crash resilience

The Secret write is two-phase: before ``handle_apply`` runs, the new intent is recorded as ``pending`` with ``finalized=false`` while ``resources`` still holds the prior finalized set. After ``handle_cleanup`` succeeds, Finalize commits the merged ``resources`` and clears ``pending`` with ``finalized=true``. A crash between the two phases leaves ``finalized=false``; the next run's cleanup takes the conservative union (``resources ∪ pending``) so no previously-owned resource ever slips past cleanup.

### Concurrent-run protection

A ``coordination.k8s.io/v1.Lease`` named ``kubernator-project-<sha1(root)[:12]>-lock`` in the same namespace serializes runs against the same root. Acquisition happens at the start of ``k8s.handle_apply``; a gevent greenlet renews every 20s against a 60s duration; release happens in ``k8s.handle_shutdown`` (always-fires). Stale leases (``renewTime + leaseDurationSeconds`` in the past) are taken over with a resourceVersion precondition; fresh leases fail the incoming run fast with the current holder's identity in the error.

### Supporting mechanism

- ``PropertyDict`` gains a minimal ``ContextProperty`` descriptor protocol. The App plugin installs a routing descriptor at ``globals.app.project`` that composes per-directory segments. A class-level fast-path set (``_descriptor_names``) keeps the legacy short-circuit recursive resolution for all non-descriptor attribute accesses — descriptor dispatch is only exercised for names ever installed as a ``ContextProperty``.
- ``App.handle_before_dir`` now creates a per-directory ``.app`` PropertyDict (chained to the parent's) so local segment assignments don't leak across siblings.
- New ``handle_cleanup`` lifecycle stage fires **after** ``handle_verify`` and before ``handle_shutdown``, so verify failures gate cleanup.

### Dry-run

Dry-run runs exercise the apply + patcher + filter paths as usual; the Lease/Secret machinery is skipped when ``state_namespace`` does not already exist (server-side dry-run would accept the namespace CREATE but not actually create it, causing every dependent in-namespace call to 404 confusingly).

### Also fixes

Pre-existing copy-paste bug in ``k8s.register()``: ``add_validator=self.api_remove_validator`` is corrected to ``add_validator=self.api_add_validator`` and ``remove_validator=self.api_remove_validator`` is added.

## Test plan

- [x] ``pyb -vX run_unit_tests analyze`` — 82 unit tests pass, flake8 clean.
- [x] ``context_property_tests.py`` (14 tests) — descriptor composition, chain inheritance, sibling isolation, single-assignment-per-context, invalid-segment rejection, descriptor-over-raw priority, legacy semantics preserved for non-descriptor names, dispatch through an intermediate PropertyDict (the ``context.app`` layout).
- [x] ``project_tests.py`` (7 tests) — registration with/without k8s, ``cleanup`` / ``state_namespace`` plumbed through, ``k8s.resources`` non-empty rejected, invalid segment names rejected via descriptor, second registration at the same context rejected, sub-context extension composes the full path.
- [x] ``k8s_project_tests.py`` (29 tests) — gzip encode/decode round-trip and stability, compression budget under 10 KiB for 200-ident payloads, prefix matcher, resource ident extraction for namespaced/cluster-scoped resources, state Secret and Lease naming determinism, scope computation across every combination of ``-I``/``-X`` (exact/prefix/both/neither), fatal errors on unmatched patterns, filter on/off semantics, new-intent grouping with and without scope filter, obsolete computation (empty prior → no deletions, removed resource marked obsolete, resource moved between projects not deleted, crashed prior uses conservative union, out-of-scope prior projects preserved), resource-merge overlay semantics.
- [x] ``project_v1`` integration test (phased, uses the kind plugin) — two-phase apply, second phase drops a resource, test asserts via ``kubectl`` that the dropped resource was deleted by the cleanup pass and that the remaining resources carry the expected dotted ``kubernator.io/project`` annotation. Requires Docker; runs in CI.