### PR TITLE
Add OpenAPI v3 validation with CEL rules; extract validator into k8s_schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,18 @@ PyBuilder project — standard `src/main/python`, `src/unittest/python`,
   - `api.py` — plugin-facing API (`ktor.*`), context hierarchy, Jinja env, JSON schema,
     diff-match-patch, HTTP, etc.
   - `merge.py`, `_json_path.py`, `_k8s_client_patches.py`, `proc.py` — internals
-  - `plugins/` — `awscli`, `eks`, `gke`, `helm`, `istio`, `k8s`, `k8s_api`, `kind`,
-    `kubeconfig`, `kubectl`, `minikube`, `template`, `terraform`, `terragrunt`
+  - `plugins/` — `awscli`, `eks`, `gke`, `helm`, `istio`, `k8s`, `k8s_api`, `k3d`,
+    `k8s_schema/`, `kind`, `kubeconfig`, `kubectl`, `minikube`, `template`, `terraform`,
+    `terragrunt`
+  - `plugins/k8s_schema/` — OpenAPI validation extracted out of `k8s.py` / `k8s_api.py`.
+    `make_validator(ctx, …)` returns either a `SwaggerV2Validator` or an
+    `OpenAPIV3Validator`. Factory default is `openapi_version="auto"` (v3 on server
+    ≥ 1.27 with v2 fallback). The v3 path fetches the discovery index cluster-first
+    (GitHub fallback), lazily fetches per-group sub-documents, enforces K8s extension
+    keywords (`x-kubernetes-list-type`, `x-kubernetes-preserve-unknown-fields`,
+    `x-kubernetes-embedded-resource`, `x-kubernetes-int-or-string`), and evaluates
+    `x-kubernetes-validations` CEL rules via `cel-python` + ported K8s extension
+    libraries (lists, regex, format, quantity, IP, CIDR) under `cel/extensions/`.
 - `src/unittest/python/` — pytest-style unit tests (`*_tests.py`)
 - `src/integrationtest/python/` — cram-style integration tests, many organized by
   `issue_NN/` reproducing specific bugs

--- a/README.md
+++ b/README.md
@@ -468,6 +468,16 @@ File discovery uses globs `*.yaml` / `*.yml` by default, configurable per-direct
   `ktor.k8s.field_validation_warn_fatal`,
   `ktor.k8s.disable_client_patches`,
   `ktor.k8s.conflict_retry_delay` — behavioural knobs, all settable at `register_plugin` time.
+* `ktor.k8s.openapi_version` (`"auto"`/`"v2"`/`"v3"`, default `"auto"`) — choose the OpenAPI dialect used for
+  client-side validation. `auto` picks v3 on Kubernetes ≥ 1.27 (where v3 went GA) and falls back to v2
+  on any v3 failure. v3 is lossless (honours `oneOf`/`anyOf`/`nullable`/`default`), enforces the K8s
+  extensions (`x-kubernetes-list-type`, `-preserve-unknown-fields`, `-embedded-resource`,
+  `-int-or-string`), and evaluates `x-kubernetes-validations` CEL rules (including
+  `optional.of`/`optional.none` and the K8s CEL libraries for lists, regex, format, quantity, IP, CIDR)
+  pre-flight. Transition rules fire against the cluster's current state at apply time.
+* `ktor.k8s.openapi_source` (`"auto"`/`"cluster"`/`"github"`, default `"auto"`) — v3 discovery source.
+  `auto` tries the cluster's `/openapi/v3` endpoint first and falls back to GitHub's
+  `api/openapi-spec/v3/` at the cluster's git tag.
 * `ktor.k8s.patch_field_excludes`, `ktor.k8s.immutable_changes` — advanced patch/diff controls.
 
 ### Helm Plugin (`helm`)

--- a/build.py
+++ b/build.py
@@ -66,6 +66,7 @@ def set_properties(project):
     project.depends_on("coloredlogs", "~=15.0")
     project.depends_on("jsonschema", "~=4.23")
     project.depends_on("diff-match-patch", ">2023.0")
+    project.depends_on("cel-python", "~=0.5")
 
     project.set_property("coverage_break_build", False)
     project.set_property("cram_fail_if_no_tests", False)

--- a/src/integrationtest/python/issue_openapi_v3/crd/.kubernator.py
+++ b/src/integrationtest/python/issue_openapi_v3/crd/.kubernator.py
@@ -1,0 +1,8 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=bool(os.environ.get("START_FRESH")),
+                         keep_running=True, profile="issue-openapi-v3")
+ktor.app.register_plugin("k8s",
+                         openapi_version=os.environ.get("OPENAPI_VERSION", "v3"))

--- a/src/integrationtest/python/issue_openapi_v3/crd/manifests.yaml
+++ b/src/integrationtest/python/issue_openapi_v3/crd/manifests.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.kubernator.example.com
+spec:
+  group: kubernator.example.com
+  names:
+    kind: Widget
+    plural: widgets
+    singular: widget
+    shortNames:
+      - wg
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              # Non-transition rule: replicas must be <= maxReplicas.
+              x-kubernetes-validations:
+                - rule: "self.replicas <= self.maxReplicas"
+                  message: "replicas must not exceed maxReplicas"
+                - rule: "self.name == oldSelf.name"
+                  message: "name is immutable"
+              required: ["replicas", "maxReplicas", "name"]
+              properties:
+                name:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 0
+                maxReplicas:
+                  type: integer
+                  minimum: 0
+                ports:
+                  # list-type: map with composite key (protocol, port) —
+                  # v3 enforces uniqueness of the composite key.
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - protocol
+                    - port
+                  items:
+                    type: object
+                    required: ["protocol", "port"]
+                    properties:
+                      protocol:
+                        type: string
+                      port:
+                        type: integer

--- a/src/integrationtest/python/issue_openapi_v3/test_fail/.kubernator.py
+++ b/src/integrationtest/python/issue_openapi_v3/test_fail/.kubernator.py
@@ -1,0 +1,10 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=False,
+                         keep_running=bool(os.environ.get("KEEP_RUNNING")),
+                         profile="issue-openapi-v3")
+ktor.app.register_plugin("k8s",
+                         openapi_version=os.environ.get("OPENAPI_VERSION", "v3"))
+ktor.k8s.load_crds(ktor.app.cwd / ".." / "crd" / "manifests.yaml", "yaml")

--- a/src/integrationtest/python/issue_openapi_v3/test_fail/manifests.yaml
+++ b/src/integrationtest/python/issue_openapi_v3/test_fail/manifests.yaml
@@ -1,0 +1,16 @@
+# CEL rule violation: replicas exceeds maxReplicas — v3 must reject.
+apiVersion: kubernator.example.com/v1
+kind: Widget
+metadata:
+  name: bad-widget
+  namespace: default
+spec:
+  name: bad-widget
+  replicas: 15
+  maxReplicas: 10
+  ports:
+    # list-type: map duplicate composite key (TCP, 80) — v3 must reject.
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 80

--- a/src/integrationtest/python/issue_openapi_v3/test_pass/.kubernator.py
+++ b/src/integrationtest/python/issue_openapi_v3/test_pass/.kubernator.py
@@ -1,0 +1,10 @@
+# flake8: noqa
+import os
+
+ktor.app.register_plugin("kind", k8s_version=os.environ["K8S_VERSION"],
+                         start_fresh=False,
+                         keep_running=bool(os.environ.get("KEEP_RUNNING")),
+                         profile="issue-openapi-v3")
+ktor.app.register_plugin("k8s",
+                         openapi_version=os.environ.get("OPENAPI_VERSION", "v3"))
+ktor.k8s.load_crds(ktor.app.cwd / ".." / "crd" / "manifests.yaml", "yaml")

--- a/src/integrationtest/python/issue_openapi_v3/test_pass/manifests.yaml
+++ b/src/integrationtest/python/issue_openapi_v3/test_pass/manifests.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernator.example.com/v1
+kind: Widget
+metadata:
+  name: good-widget
+  namespace: default
+spec:
+  name: good-widget
+  replicas: 3
+  maxReplicas: 10
+  ports:
+    - protocol: TCP
+      port: 80
+    - protocol: UDP
+      port: 53

--- a/src/integrationtest/python/issue_openapi_v3_tests.py
+++ b/src/integrationtest/python/issue_openapi_v3_tests.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+import os  # noqa: E402
+
+
+class IssueOpenAPIV3Test(IntegrationTestSupport):
+    """End-to-end exercise for the OpenAPI v3 validator and CEL rules.
+
+    Phases:
+      1. Apply the CRD defining Widget with x-kubernetes-validations
+         (non-transition rule on replicas/maxReplicas, transition rule
+         on immutable name, plus a list-type: map key).
+      2. Apply a valid Widget — should succeed under v3.
+      3. Apply an invalid Widget (rule + list-type violations) —
+         should fail under v3.
+
+    Runs only on the most recent supported Kubernetes version (>= 1.27
+    for v3 availability; the test matrix starts at 1.29). Setting
+    ``OPENAPI_VERSION=v2`` in the environment lets CI verify v2
+    continues to accept the CR unchanged — v2 built-in schemas don't
+    carry CEL rules, and CRD schema validation is still applied by
+    the cluster server-side regardless of the client's OpenAPI mode.
+    """
+
+    def test_issue_openapi_v3(self):
+        issue_dir = Path(__file__).parent / "issue_openapi_v3"
+        crd_dir = issue_dir / "crd"
+        pass_dir = issue_dir / "test_pass"
+        fail_dir = issue_dir / "test_fail"
+
+        k8s_version = self.K8S_TEST_VERSIONS[-1]
+        os.environ["K8S_VERSION"] = k8s_version
+        os.environ["OPENAPI_VERSION"] = "v3"
+
+        # Phase 1: bring up cluster and apply CRD.
+        os.environ["START_FRESH"] = "1"
+        os.environ["KEEP_RUNNING"] = "1"
+        self.run_module_test("kubernator", "-p", str(crd_dir), "-v", "DEBUG",
+                             "apply", "--yes")
+
+        # Phase 2: valid widget — should succeed.
+        os.environ["START_FRESH"] = ""
+        os.environ["KEEP_RUNNING"] = "1"
+        self.run_module_test("kubernator", "-p", str(pass_dir), "-v", "DEBUG",
+                             "apply", "--yes")
+
+        # Phase 3: invalid widget — kubernator must surface the CEL
+        # and list-type violations client-side (v3).
+        os.environ["START_FRESH"] = ""
+        os.environ["KEEP_RUNNING"] = ""
+        with self.assertRaises(AssertionError):
+            self.run_module_test("kubernator", "-p", str(fail_dir), "-v", "DEBUG",
+                                 "apply", "--yes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/kubernator/plugins/istio.py
+++ b/src/main/python/kubernator/plugins/istio.py
@@ -28,13 +28,13 @@ import yaml
 
 from kubernator.api import (KubernatorPlugin, scan_dir,
                             TemplateEngine,
-                            load_remote_file,
                             FileType,
                             StripNL,
                             Globs,
                             get_golang_os,
                             get_golang_machine,
                             prepend_os_path, jp, load_file)
+from kubernator.plugins import k8s_schema
 from kubernator.plugins.k8s_api import api_exc_format_body
 from kubernator.plugins.k8s_api import K8SResourcePluginMixin
 
@@ -175,12 +175,7 @@ class IstioPlugin(KubernatorPlugin, K8SResourcePluginMixin):
             "yaml")
 
         # This plugin only deals with Istio Operator, so only load that stuff
-        self.resource_definitions_schema = load_remote_file(logger,
-                                                            f"https://raw.githubusercontent.com/kubernetes/kubernetes/"
-                                                            f"{self.context.k8s.server_git_version}"
-                                                            f"/api/openapi-spec/swagger.json",
-                                                            FileType.JSON)
-        self._populate_resource_definitions()
+        self.validator = k8s_schema.make_validator(self.context)
 
         crd_operator_version = (1, 23, 4) if self.client_version >= (1, 24, 0) else self.client_version
         self.add_remote_crds(

--- a/src/main/python/kubernator/plugins/k8s.py
+++ b/src/main/python/kubernator/plugins/k8s.py
@@ -36,13 +36,13 @@ from kubernator.api import (KubernatorPlugin,
                             scan_dir,
                             load_file,
                             FileType,
-                            load_remote_file,
                             StripNL,
                             install_python_k8s_client,
                             TemplateEngine,
                             calling_frame_source,
                             parse_yaml_docs)
 from kubernator.merge import extract_merge_instructions, apply_merge_instructions
+from kubernator.plugins import k8s_schema
 from kubernator.plugins.k8s_api import (K8SResourcePluginMixin,
                                         K8SResource,
                                         K8SResourcePatchType,
@@ -108,11 +108,18 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
     def register(self,
                  field_validation="Warn",
                  field_validation_warn_fatal=True,
-                 disable_client_patches=False):
+                 disable_client_patches=False,
+                 openapi_version="auto",
+                 openapi_source="auto"):
         self.context.app.register_plugin("kubeconfig")
 
         if field_validation not in VALID_FIELD_VALIDATION:
             raise ValueError("'field_validation' must be one of %s" % (", ".join(VALID_FIELD_VALIDATION)))
+
+        if openapi_version not in ("auto", "v2", "v3"):
+            raise ValueError("'openapi_version' must be auto|v2|v3")
+        if openapi_source not in ("auto", "cluster", "github"):
+            raise ValueError("'openapi_source' must be auto|cluster|github")
 
         context = self.context
         context.globals.k8s = dict(patch_field_excludes=("^/metadata/managedFields",
@@ -120,6 +127,8 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                                                          "^/metadata/creationTimestamp",
                                                          "^/metadata/resourceVersion",
                                                          ),
+                                   openapi_version=openapi_version,
+                                   openapi_source=openapi_source,
                                    immutable_changes={("apps", "DaemonSet"): K8SPropagationPolicy.BACKGROUND,
                                                       ("apps", "StatefulSet"): K8SPropagationPolicy.ORPHAN,
                                                       ("apps", "Deployment"): K8SPropagationPolicy.ORPHAN,
@@ -193,14 +202,7 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         logger.info("Switching to Kubernetes client version %s", ".".join(self.embedded_pkg_version))
         self._setup_client()
 
-        logger.debug("Reading Kubernetes OpenAPI spec for %s", k8s.server_git_version)
-
-        k8s_def = load_remote_file(logger, f"https://raw.githubusercontent.com/kubernetes/kubernetes/"
-                                           f"{k8s.server_git_version}/api/openapi-spec/swagger.json",
-                                   FileType.JSON)
-        self.resource_definitions_schema = k8s_def
-
-        self._populate_resource_definitions()
+        self.validator = k8s_schema.make_validator(self.context)
 
     def _setup_client(self):
         from kubernetes import client
@@ -510,6 +512,19 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
         try:
             remote_resource = resource.get()
             logger.trace("Current resource %s: %s", resource, remote_resource)
+            # v3 evaluates transition rules here (oldSelf bound to the
+            # server's current state). v2 has no transition rules and
+            # the resource was already schema-validated at add_resource
+            # time, so skip a second pass.
+            if self.validator.version == "v3":
+                transition_errors = list(
+                    self.validator.iter_errors(resource.manifest, resource.rdef,
+                                               old_manifest=remote_resource))
+                if transition_errors:
+                    for err in transition_errors:
+                        logger.error("Transition rule violation on %s from %s: %s",
+                                     resource, resource.source, err)
+                    raise transition_errors[0]
         except ApiException as e:
             try:
                 if e.status == 404:

--- a/src/main/python/kubernator/plugins/k8s_api.py
+++ b/src/main/python/kubernator/plugins/k8s_api.py
@@ -16,22 +16,17 @@
 #   limitations under the License.
 #
 
-import base64
 import json
 import re
 from collections import namedtuple
-from collections.abc import Callable, Mapping, MutableMapping, Sequence, Iterable
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from enum import Enum, auto
 from functools import partial, wraps
 from pathlib import Path
 from typing import Union, Optional
 
 import yaml
-from jsonschema._format import FormatChecker
-from jsonschema._keywords import required
 from jsonschema.exceptions import ValidationError
-from jsonschema.validators import extend, Draft7Validator
-from openapi_schema_validator import OAS31Validator
 
 from kubernator.api import load_file, FileType, load_remote_file, calling_frame_source, parse_yaml_docs
 
@@ -78,32 +73,6 @@ K8S_WARNING_HEADER = re.compile(r'(?:,\s*)?(\d{3})\s+(\S+)\s+"(.+?)(?<!\\)"(?:\s
 UPPER_FOLLOWED_BY_LOWER_RE = re.compile(r"(.)([A-Z][a-z]+)")
 LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE = re.compile(r"([a-z0-9])([A-Z])")
 
-K8S_MINIMAL_RESOURCE_SCHEMA = {
-    "properties": {
-        "apiVersion": {
-            "type": "string"
-        },
-        "kind": {
-            "type": "string"
-        },
-        "metadata": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                }
-            },
-            "required": ["name"]
-        }
-    },
-    "type": "object",
-    "required": ["apiVersion", "kind"]
-}
-K8S_MINIMAL_RESOURCE_VALIDATOR = Draft7Validator(K8S_MINIMAL_RESOURCE_SCHEMA)
-
 CLUSTER_RESOURCE_PATH = re.compile(r"^/apis?/(?:[^/]+/){1,2}([^/]+)$")
 NAMESPACED_RESOURCE_PATH = re.compile(r"^/apis?/(?:[^/]+/){1,2}namespaces/[^/]+/([^/]+)$")
 
@@ -120,69 +89,6 @@ class K8SPropagationPolicy(Enum):
 
     def __init__(self, policy):
         self.policy = policy
-
-
-def is_integer(instance):
-    # bool inherits from int, so ensure bools aren't reported as ints
-    if isinstance(instance, bool):
-        return False
-    return isinstance(instance, int)
-
-
-def is_string(instance):
-    return isinstance(instance, str)
-
-
-def type_validator(validator, data_type, instance, schema):
-    if instance is None:
-        return
-
-    if data_type == "string" and schema.get("format") == "int-or-string":
-        if not (is_string(instance) or is_integer(instance)):
-            yield ValidationError("%r is not of type %s" % (instance, "int-or-string"))
-    elif not validator.is_type(instance, data_type):
-        yield ValidationError("%r is not of type %s" % (instance, data_type))
-
-
-K8SValidator = extend(OAS31Validator, validators={
-    "type": type_validator,
-    "required": required
-})
-
-k8s_format_checker = FormatChecker()
-
-
-@k8s_format_checker.checks("int32")
-def check_int32(value):
-    return value is not None and (-2147483648 < value < 2147483647)
-
-
-@k8s_format_checker.checks("int64")
-def check_int64(value):
-    return value is not None and (-9223372036854775808 < value < 9223372036854775807)
-
-
-@k8s_format_checker.checks("float")
-def check_float(value):
-    return value is not None and (-3.4E+38 < value < +3.4E+38)
-
-
-@k8s_format_checker.checks("double")
-def check_double(value):
-    return value is not None and (-1.7E+308 < value < +1.7E+308)
-
-
-@k8s_format_checker.checks("byte", ValueError)
-def check_byte(value):
-    if value is None:
-        return False
-    base64.b64decode(value, validate=True)
-    return True
-
-
-@k8s_format_checker.checks("int-or-string")
-def check_int_or_string(value):
-    return check_int32(value) if is_integer(value) else is_string(value)
 
 
 def to_group_and_version(api_version):
@@ -591,11 +497,22 @@ class K8SResource:
 
 class K8SResourcePluginMixin:
     def __init__(self):
-        self.resource_definitions: MutableMapping[K8SResourceDefKey, K8SResourceDef] = {}
-        self.resource_paths: MutableMapping[K8SResourceDefKey, MutableMapping[str, dict]] = {}
+        self.validator = None
         self.resources: MutableMapping[K8SResourceKey, K8SResource] = {}
 
-        self.resource_definitions_schema = None
+    def _require_validator(self):
+        if self.validator is None:
+            raise RuntimeError(
+                "K8S validator not initialised; handle_start() must run first")
+        return self.validator
+
+    @property
+    def resource_definitions(self) -> MutableMapping[K8SResourceDefKey, K8SResourceDef]:
+        return self._require_validator().resource_definitions
+
+    @property
+    def resource_paths(self) -> MutableMapping[K8SResourceDefKey, MutableMapping[str, dict]]:
+        return self._require_validator().resource_paths
 
     def add_resources(self, manifests: Union[str, list, dict], source: Union[str, Path] = None):
         if not source:
@@ -683,12 +600,7 @@ class K8SResourcePluginMixin:
         return [self.add_crd(m, source or url) for m in manifests if m]
 
     def get_api_versions(self):
-        api_versions = set()
-        for rdef in self.resource_definitions:
-            api_version = f"{f'{rdef.group}/' if rdef.group else ''}{rdef.version}"
-            if api_version not in api_versions:
-                api_versions.add(api_version)
-        return sorted(api_versions)
+        return self.validator.api_versions()
 
     def _create_resource(self, manifest: dict, source: Union[str, Path] = None):
         resource_description = K8SResource.get_manifest_description(manifest, source)
@@ -741,92 +653,12 @@ class K8SResourcePluginMixin:
         yield from filter(func, self.resources.values())
 
     def _validate_resource(self, manifest: dict, source: Union[str, Path] = None):
-        for error in self._yield_manifest_rdef(manifest):
-            if isinstance(error, Exception):
-                yield error
-            else:
-                rdef = error
-                k8s_validator = K8SValidator(rdef.schema,
-                                             format_checker=k8s_format_checker)
-                yield from k8s_validator.iter_errors(manifest)
+        yield from self._require_validator().iter_manifest_errors(manifest)
 
     def _get_manifest_rdef(self, manifest):
-        for error in self._yield_manifest_rdef(manifest):
-            if isinstance(error, Exception):
-                raise error
-            else:
-                return error
-
-    def _yield_manifest_rdef(self, manifest):
-        error = None
-        for error in K8S_MINIMAL_RESOURCE_VALIDATOR.iter_errors(manifest):
-            yield error
-
-        if error:
-            return
-
-        key = K8SResourceDefKey(*to_group_and_version(manifest["apiVersion"]), manifest["kind"])
-
-        try:
-            yield self.resource_definitions[key]
-        except KeyError:
-            yield ValidationError("%s is not a defined Kubernetes resource" % (key,),
-                                  validator=K8S_MINIMAL_RESOURCE_VALIDATOR,
-                                  validator_value=key,
-                                  instance=manifest,
-                                  schema=K8S_MINIMAL_RESOURCE_SCHEMA)
+        return self._require_validator().get_manifest_rdef(manifest)
 
     def _add_crd(self, resource: K8SResource):
         for crd in K8SResourceDef.from_resource(resource):
             self.logger.info("Adding K8S CRD definition %s", crd.key)
             self.resource_definitions[crd.key] = crd
-
-    def _populate_resource_definitions(self):
-        k8s_def = self.resource_definitions_schema
-
-        def k8s_resource_def_key(v: Mapping[str, Union[list, Mapping]]) -> Iterable[K8SResourceDefKey]:
-            gvks = v.get("x-kubernetes-group-version-kind")
-            if gvks:
-                if isinstance(gvks, Mapping):
-                    gvk = gvks
-                    yield K8SResourceDefKey(gvk["group"],
-                                            gvk["version"],
-                                            gvk["kind"])
-                else:
-                    for gvk in gvks:
-                        yield K8SResourceDefKey(gvk["group"],
-                                                gvk["version"],
-                                                gvk["kind"])
-
-        paths = k8s_def["paths"]
-        for path, actions in paths.items():
-            path_rdk = None
-            path_actions = []
-            for action, action_details in actions.items():
-                if action == "parameters":
-                    continue
-                rdks = list(k8s_resource_def_key(action_details))
-                if rdks:
-                    assert len(rdks) == 1
-                    rdk = rdks[0]
-                    if path_rdk:
-                        if path_rdk != rdk:
-                            raise ValueError(f"Encountered path action x-kubernetes-group-version-kind conflict: "
-                                             f"{path}: {actions}")
-                        path_actions.append(action_details["x-kubernetes-action"])
-                    else:
-                        path_rdk = rdk
-
-            if path_rdk:
-                rdef_paths = self.resource_paths.get(path_rdk)
-                if not rdef_paths:
-                    rdef_paths = {}
-                    self.resource_paths[path_rdk] = rdef_paths
-                rdef_paths[path] = actions
-
-        for k, schema in k8s_def["definitions"].items():
-            # This short-circuits the resolution of the references to the top of the document
-            schema["definitions"] = k8s_def["definitions"]
-            for key in k8s_resource_def_key(schema):
-                for rdef in K8SResourceDef.from_manifest(key, schema, self.resource_paths):
-                    self.resource_definitions[key] = rdef

--- a/src/main/python/kubernator/plugins/k8s_schema/__init__.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/__init__.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""OpenAPI validation factory for Kubernetes manifests.
+
+Two validator implementations live side-by-side:
+
+- :class:`SwaggerV2Validator` — fetches ``swagger.json`` from GitHub
+  and validates using OAS31 over the legacy K8s OpenAPI v2 dialect.
+- :class:`OpenAPIV3Validator` — cluster-first discovery of
+  ``/openapi/v3`` with GitHub fallback; lazy per-group fetch; OAS30 +
+  K8s extension keyword enforcement + CEL rule evaluation.
+
+Selection is resolved by :func:`make_validator` against two context
+knobs (``context.globals.k8s.openapi_version`` and
+``.openapi_source``) that can be overridden by explicit kwargs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, Optional
+
+from kubernator.api import config_get
+from kubernator.plugins.k8s_schema.base import (K8S_MINIMAL_RESOURCE_SCHEMA,
+                                                K8S_MINIMAL_RESOURCE_VALIDATOR,
+                                                OpenAPIValidator)
+from kubernator.plugins.k8s_schema.sources import ClusterSource, GitHubSource
+from kubernator.plugins.k8s_schema.v2 import SwaggerV2Validator
+from kubernator.plugins.k8s_schema.v3 import OpenAPIV3Validator
+
+logger = logging.getLogger("kubernator.k8s_schema")
+
+
+VERSION_GATE_MINOR = 27  # OpenAPI v3 GA milestone (Kubernetes 1.27)
+
+
+def _server_minor(context) -> Optional[int]:
+    try:
+        minor = context.k8s.server_version[1]
+    except (AttributeError, IndexError, KeyError):
+        return None
+    try:
+        return int(minor)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve(context, *, openapi_version: str, openapi_source: str):
+    """Return the effective (version, source) pair, honoring
+    explicit kwargs over context values."""
+    ctx_k8s = getattr(context, "k8s", None)
+    ctx_globals = getattr(getattr(context, "globals", None), "k8s", None)
+
+    if openapi_version == "auto":
+        openapi_version = (config_get(ctx_globals, "openapi_version", "auto")
+                           if ctx_globals is not None else "auto")
+    if openapi_source == "auto":
+        openapi_source = (config_get(ctx_globals, "openapi_source", "auto")
+                          if ctx_globals is not None else "auto")
+
+    if openapi_version not in ("auto", "v2", "v3"):
+        raise ValueError(f"openapi_version must be auto|v2|v3, got {openapi_version!r}")
+    if openapi_source not in ("auto", "cluster", "github"):
+        raise ValueError(f"openapi_source must be auto|cluster|github, got {openapi_source!r}")
+
+    return openapi_version, openapi_source, ctx_k8s
+
+
+def _sources_for(context, openapi_source: str) -> list:
+    k8s = context.k8s
+    git_version = k8s.server_git_version
+    api_client = getattr(k8s, "client", None)
+
+    cluster = ClusterSource(api_client) if api_client is not None else None
+    github = GitHubSource(git_version)
+
+    if openapi_source == "cluster":
+        if cluster is None:
+            raise RuntimeError("openapi_source='cluster' requested but no K8s API client is available")
+        return [cluster]
+    if openapi_source == "github":
+        return [github]
+    # auto
+    out = []
+    if cluster is not None:
+        out.append(cluster)
+    out.append(github)
+    return out
+
+
+def make_validator(
+        context,
+        *,
+        openapi_version: Literal["auto", "v2", "v3"] = "auto",
+        openapi_source: Literal["auto", "cluster", "github"] = "auto",
+) -> OpenAPIValidator:
+    """Build an OpenAPI validator.
+
+    ``openapi_version``:
+        ``auto`` (default): use v3 on server ≥ 1.27, fall back to v2
+        on any v3 failure; use v2 directly when server < 1.27.
+        ``v3``: force v3; no version gate, no v2 fallback.
+        ``v2``: always use v2.
+
+    ``openapi_source`` (only meaningful for v3):
+        ``auto``: cluster-first, GitHub fallback.
+        ``cluster``: cluster only (no GitHub).
+        ``github``: GitHub only (skip cluster).
+    """
+    openapi_version, openapi_source, _ = _resolve(
+        context, openapi_version=openapi_version, openapi_source=openapi_source)
+
+    minor = _server_minor(context)
+
+    if openapi_version == "v2":
+        return _load_v2(context)
+
+    if openapi_version == "auto" and minor is not None and minor < VERSION_GATE_MINOR:
+        logger.info("Kubernetes server is < 1.%d — using OpenAPI v2",
+                    VERSION_GATE_MINOR)
+        return _load_v2(context)
+
+    if openapi_version == "v3" and minor is not None and minor < VERSION_GATE_MINOR:
+        logger.warning("openapi_version='v3' forced on server < 1.%d "
+                       "(OpenAPI v3 may not be available)", VERSION_GATE_MINOR)
+
+    try:
+        sources = _sources_for(context, openapi_source)
+        v3 = OpenAPIV3Validator(context, sources=sources)
+        v3.load()
+        logger.info("Using OpenAPI v3 for Kubernetes server %s",
+                    getattr(context.k8s, "server_git_version", "(unknown)"))
+        return v3
+    except Exception as e:  # noqa: BLE001
+        if openapi_version == "v3":
+            raise
+        logger.warning("Falling back to OpenAPI v2: %s", e)
+        return _load_v2(context)
+
+
+def _load_v2(context):
+    v = SwaggerV2Validator(context)
+    v.load()
+    return v
+
+
+__all__ = [
+    "K8S_MINIMAL_RESOURCE_SCHEMA",
+    "K8S_MINIMAL_RESOURCE_VALIDATOR",
+    "OpenAPIValidator",
+    "SwaggerV2Validator",
+    "OpenAPIV3Validator",
+    "make_validator",
+]

--- a/src/main/python/kubernator/plugins/k8s_schema/base.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/base.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+from typing import Literal, Optional
+
+from jsonschema._format import FormatChecker
+from jsonschema.exceptions import ValidationError
+from jsonschema.validators import Draft7Validator
+
+from kubernator.plugins.k8s_api import (K8SResourceDef,
+                                        K8SResourceDefKey,
+                                        to_group_and_version)
+
+
+K8S_MINIMAL_RESOURCE_SCHEMA = {
+    "properties": {
+        "apiVersion": {"type": "string"},
+        "kind": {"type": "string"},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "namespace": {"type": "string"},
+            },
+            "required": ["name"],
+        },
+    },
+    "type": "object",
+    "required": ["apiVersion", "kind"],
+}
+K8S_MINIMAL_RESOURCE_VALIDATOR = Draft7Validator(K8S_MINIMAL_RESOURCE_SCHEMA)
+
+
+def extract_gvk_keys(obj: Mapping) -> Iterable[K8SResourceDefKey]:
+    """Yield :class:`K8SResourceDefKey` for each ``x-kubernetes-group-version-kind``
+    entry on *obj*. Handles both the single-dict and list-of-dicts shapes
+    that K8s OpenAPI documents use."""
+    gvks = obj.get("x-kubernetes-group-version-kind")
+    if not gvks:
+        return
+    if isinstance(gvks, Mapping):
+        gvks = [gvks]
+    for gvk in gvks:
+        yield K8SResourceDefKey(gvk["group"], gvk["version"], gvk["kind"])
+
+
+def is_integer(instance):
+    # bool inherits from int, so ensure bools aren't reported as ints
+    if isinstance(instance, bool):
+        return False
+    return isinstance(instance, int)
+
+
+def is_string(instance):
+    return isinstance(instance, str)
+
+
+def type_validator(validator, data_type, instance, schema):
+    if instance is None:
+        return
+
+    if (data_type == "string"
+            and (schema.get("format") == "int-or-string"
+                 or schema.get("x-kubernetes-int-or-string") is True)):
+        if not (is_string(instance) or is_integer(instance)):
+            yield ValidationError("%r is not of type %s" % (instance, "int-or-string"))
+    elif not validator.is_type(instance, data_type):
+        yield ValidationError("%r is not of type %s" % (instance, data_type))
+
+
+k8s_format_checker = FormatChecker()
+
+
+@k8s_format_checker.checks("int32")
+def check_int32(value):
+    return value is not None and (-2147483648 < value < 2147483647)
+
+
+@k8s_format_checker.checks("int64")
+def check_int64(value):
+    return value is not None and (-9223372036854775808 < value < 9223372036854775807)
+
+
+@k8s_format_checker.checks("float")
+def check_float(value):
+    return value is not None and (-3.4E+38 < value < +3.4E+38)
+
+
+@k8s_format_checker.checks("double")
+def check_double(value):
+    return value is not None and (-1.7E+308 < value < +1.7E+308)
+
+
+@k8s_format_checker.checks("byte", ValueError)
+def check_byte(value):
+    if value is None:
+        return False
+    base64.b64decode(value, validate=True)
+    return True
+
+
+@k8s_format_checker.checks("int-or-string")
+def check_int_or_string(value):
+    return check_int32(value) if is_integer(value) else is_string(value)
+
+
+class OpenAPIValidator:
+    """Concrete base class for OpenAPI-backed Kubernetes manifest validators.
+
+    Subclasses implement :meth:`load`, :meth:`iter_errors`, and
+    :meth:`api_versions`; this base supplies the manifest-level
+    entry points (:meth:`iter_manifest_errors`, :meth:`get_manifest_rdef`)
+    shared by v2 and v3 so the K8s plugin mixin can delegate all
+    validation to the validator without caring about version or
+    minimal-schema details.
+    """
+
+    version: Literal["v2", "v3"]
+    resource_definitions: MutableMapping[K8SResourceDefKey, K8SResourceDef]
+    resource_paths: MutableMapping[K8SResourceDefKey, Mapping[str, dict]]
+
+    def load(self) -> None:
+        raise NotImplementedError
+
+    def iter_errors(
+            self,
+            manifest: Mapping,
+            rdef: K8SResourceDef,
+            *,
+            old_manifest: Optional[Mapping] = None,
+    ) -> Iterator[ValidationError]:
+        raise NotImplementedError
+
+    def api_versions(self) -> Iterable[str]:
+        raise NotImplementedError
+
+    # -- manifest-level validation shared across versions ----------------
+
+    def get_manifest_rdef(self, manifest: Mapping) -> K8SResourceDef:
+        """Resolve a manifest to its :class:`K8SResourceDef`.
+        Raises :class:`ValidationError` if the kind is unknown."""
+        key = K8SResourceDefKey(*to_group_and_version(manifest["apiVersion"]),
+                                manifest["kind"])
+        try:
+            return self.resource_definitions[key]
+        except KeyError:
+            raise ValidationError(
+                f"{key} is not a defined Kubernetes resource",
+                validator=K8S_MINIMAL_RESOURCE_VALIDATOR,
+                validator_value=key,
+                instance=manifest,
+                schema=K8S_MINIMAL_RESOURCE_SCHEMA,
+            )
+
+    def iter_manifest_errors(
+            self,
+            manifest: Mapping,
+            *,
+            old_manifest: Optional[Mapping] = None,
+    ) -> Iterator[ValidationError]:
+        """Validate a manifest end-to-end: minimal envelope check →
+        rdef lookup → full schema (and CEL) validation."""
+        sentinel: Optional[ValidationError] = None
+        for err in K8S_MINIMAL_RESOURCE_VALIDATOR.iter_errors(manifest):
+            sentinel = err
+            yield err
+        if sentinel is not None:
+            return
+        try:
+            rdef = self.get_manifest_rdef(manifest)
+        except ValidationError as e:
+            yield e
+            return
+        yield from self.iter_errors(manifest, rdef, old_manifest=old_manifest)

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/__init__.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/__init__.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""Kubernetes CEL evaluator for ``x-kubernetes-validations`` rules.
+
+Discovery (rule walk) is eager but cheap; compilation and evaluation
+are lazy. The cache is keyed by rule expression text, so identical
+rules across resources share a single compiled program.
+
+Transition rules (those referencing ``oldSelf``) are skipped when no
+``old_manifest`` is supplied, matching server behavior; rules marked
+``optionalSelf`` / ``optionalOldSelf`` receive optional-wrapped
+bindings via the :mod:`…cel.extensions.optional_lib` shim (cel-python
+has no native ``optional<T>``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any, Mapping, Optional
+
+import celpy
+import celpy.celtypes as ct
+from celpy.evaluation import CELEvalError
+from celpy.celparser import CELParseError
+from jsonschema.exceptions import ValidationError
+
+from kubernator.plugins.k8s_schema.cel.extensions import register_all
+from kubernator.plugins.k8s_schema.cel.extensions import optional_lib
+from kubernator.plugins.k8s_schema.cel.rules import (ARRAY_ITEM,
+                                                     collect_rules,
+                                                     resolve_path)
+
+logger = logging.getLogger("kubernator.k8s_schema.cel")
+
+
+_CEL_TYPES = (
+    ct.BoolType, ct.BytesType, ct.DoubleType, ct.DurationType,
+    ct.IntType, ct.ListType, ct.MapType, ct.StringType,
+    ct.TimestampType, ct.UintType,
+)
+
+#: Sentinel bound into every activation as ``optional`` so rule text
+#: like ``optional.of(x)`` resolves via method-call rewrite into
+#: ``of(optional, x)``.
+_OPTIONAL_BINDING = optional_lib.OPTIONAL_SENTINEL
+
+_MISSING = object()
+
+
+def _to_cel(value: Any):
+    """Convert a Python/JSON value into the equivalent celtype.
+
+    Mirrors :func:`celpy.json_to_cel` but tolerates already-converted
+    values and honors ``None`` (mapped to CEL null).
+    """
+    if value is None:
+        return None
+    if isinstance(value, _CEL_TYPES):
+        return value
+    return celpy.json_to_cel(value)
+
+
+def _optional_bind(value: Any):
+    """Produce the optional-wrapped binding for ``self`` / ``oldSelf``
+    when the declaring rule sets ``optionalSelf`` / ``optionalOldSelf``
+    to true."""
+    if value is _MISSING or value is None:
+        return optional_lib.NONE
+    return optional_lib.wrap(_to_cel(value))
+
+
+class CELEvaluator:
+    """Single-instance CEL runtime: builds one ``Environment`` and
+    caches compiled programs by rule text for the lifetime of the
+    evaluator (== one Kubernator run, given the validator factory)."""
+
+    def __init__(self):
+        # No annotations — ``self`` and ``oldSelf`` may bind to any
+        # value (scalar, list, map). celpy's type-checker only
+        # constrains when annotations are explicitly given.
+        self._env = celpy.Environment()
+        self._functions = register_all()
+        self._program_cache: dict[str, Optional[celpy.Runner]] = {}
+        self._rules_cache: dict[int, list[tuple[list[Any], dict]]] = {}
+
+    # ------------------------------------------------------------------ caches
+
+    def _program(self, expression: str) -> Optional[celpy.Runner]:
+        if expression in self._program_cache:
+            return self._program_cache[expression]
+        try:
+            ast = self._env.compile(expression)
+            program = self._env.program(ast, functions=self._functions)
+        except (CELParseError, CELEvalError, ValueError) as e:
+            logger.warning("CEL rule failed to compile (%r): %s", expression, e)
+            self._program_cache[expression] = None
+            return None
+        self._program_cache[expression] = program
+        return program
+
+    def _rules_for(self, schema: Mapping) -> list[tuple[list[Any], dict]]:
+        key = id(schema)
+        cached = self._rules_cache.get(key)
+        if cached is None:
+            cached = list(collect_rules(schema))
+            self._rules_cache[key] = cached
+        return cached
+
+    # ------------------------------------------------------------------ public
+
+    def iter_rule_errors(self,
+                         manifest: Mapping,
+                         schema: Mapping,
+                         *,
+                         old_manifest: Optional[Mapping] = None,
+                         ) -> Iterator[ValidationError]:
+        """Evaluate every CEL rule in *schema* against *manifest* (and,
+        for transition rules, *old_manifest*). Yields one
+        ``ValidationError`` per failing rule."""
+        rules = self._rules_for(schema)
+        if not rules:
+            return
+
+        for path, rule in rules:
+            yield from self._eval_rule(path, rule, manifest, old_manifest)
+
+    # ----------------------------------------------------------------- helpers
+
+    def _eval_rule(self,
+                   path: list[Any],
+                   rule: Mapping,
+                   manifest: Mapping,
+                   old_manifest: Optional[Mapping]) -> Iterator[ValidationError]:
+        expression = rule.get("rule")
+        if not expression:
+            return
+
+        is_transition = "oldSelf" in expression
+        optional_self = bool(rule.get("optionalSelf"))
+        optional_old_self = bool(rule.get("optionalOldSelf"))
+
+        values = list(resolve_path(manifest, path))
+        if not values:
+            if optional_self:
+                values = [_MISSING]
+            else:
+                return
+
+        for value in values:
+            if is_transition:
+                if old_manifest is None:
+                    old_values: list = []
+                else:
+                    old_values = list(resolve_path(old_manifest, path))
+                if not old_values:
+                    if not optional_old_self:
+                        # server-side semantics: transition rules with
+                        # no prior state simply don't fire
+                        continue
+                    old_values = [_MISSING]
+                old_value = old_values[0]
+            else:
+                old_value = _MISSING
+
+            yield from self._evaluate_one(expression, rule, path,
+                                          value, old_value,
+                                          is_transition,
+                                          optional_self,
+                                          optional_old_self)
+
+    def _evaluate_one(self,
+                      expression: str,
+                      rule: Mapping,
+                      path: list[Any],
+                      self_value: Any,
+                      old_value: Any,
+                      is_transition: bool,
+                      optional_self: bool,
+                      optional_old_self: bool) -> Iterator[ValidationError]:
+        program = self._program(expression)
+        if program is None:
+            yield ValidationError(
+                f"CEL rule could not be compiled: {expression!r}",
+                validator="x-kubernetes-validations",
+                validator_value=rule,
+                instance=None if self_value is _MISSING else self_value,
+                path=tuple(_path_str(s) for s in path),
+            )
+            return
+
+        activation: dict[str, Any] = {"optional": _OPTIONAL_BINDING}
+        activation["self"] = (_optional_bind(self_value) if optional_self
+                              else _to_cel(self_value))
+        if is_transition:
+            activation["oldSelf"] = (_optional_bind(old_value) if optional_old_self
+                                     else _to_cel(old_value))
+
+        try:
+            result = program.evaluate(activation)
+        except CELEvalError as e:
+            yield ValidationError(
+                f"CEL rule {expression!r} could not be evaluated: {e}",
+                validator="x-kubernetes-validations",
+                validator_value=rule,
+                instance=None if self_value is _MISSING else self_value,
+                path=tuple(_path_str(s) for s in path),
+            )
+            return
+
+        if not isinstance(result, (bool, ct.BoolType)):
+            yield ValidationError(
+                f"CEL rule {expression!r} returned non-bool {result!r}",
+                validator="x-kubernetes-validations",
+                validator_value=rule,
+                instance=None if self_value is _MISSING else self_value,
+                path=tuple(_path_str(s) for s in path),
+            )
+            return
+
+        if bool(result):
+            return
+
+        message = self._compute_message(rule, activation)
+        field_path = rule.get("fieldPath")
+        full_path = list(path)
+        if field_path:
+            # fieldPath is a JSONPath fragment like ".spec.replicas" — append.
+            full_path.append(str(field_path))
+
+        yield ValidationError(
+            message,
+            validator=rule.get("reason", "x-kubernetes-validations"),
+            validator_value=rule,
+            instance=None if self_value is _MISSING else self_value,
+            path=tuple(_path_str(s) for s in full_path),
+        )
+
+    def _compute_message(self, rule: Mapping, activation: Mapping) -> str:
+        message_expr = rule.get("messageExpression")
+        if message_expr:
+            program = self._program(message_expr)
+            if program is not None:
+                try:
+                    out = program.evaluate(activation)
+                    return str(out)
+                except CELEvalError as e:
+                    logger.debug("messageExpression %r failed to evaluate: %s",
+                                 message_expr, e)
+        msg = rule.get("message")
+        if msg:
+            return str(msg)
+        return f"CEL rule {rule.get('rule')!r} failed"
+
+
+def _path_str(seg: Any) -> str:
+    return "[*]" if seg is ARRAY_ITEM else str(seg)
+
+
+__all__ = ["CELEvaluator"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/__init__.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/__init__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from kubernator.plugins.k8s_schema.cel.extensions import (cidr_lib,
+                                                          format_lib,
+                                                          ip_lib,
+                                                          lists,
+                                                          optional_lib,
+                                                          quantity,
+                                                          regex_lib)
+
+_MODULES = (lists, regex_lib, format_lib, quantity, ip_lib, cidr_lib, optional_lib)
+
+
+def register_all() -> list:
+    """Returns a flat list of CEL callables pulled from each extension
+    module's ``__all__`` — pass as
+    ``celpy.Environment.program(ast, functions=...)``.
+
+    celpy binds each function to its Python ``__name__`` and rewrites
+    ``obj.method(arg)`` as ``method(obj, arg)``, so a single list entry
+    covers both call shapes.
+    """
+    functions: list = []
+    for module in _MODULES:
+        for name in module.__all__:
+            functions.append(getattr(module, name))
+    return functions
+
+
+__all__ = ["register_all"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/cidr_lib.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/cidr_lib.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: CIDR parsing.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/cidr.go``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import celpy.celtypes as ct
+
+
+def _parse_network(value):
+    if isinstance(value, ct.MapType) and "_cidr" in value:
+        return ipaddress.ip_network(str(value["cidr"]), strict=False)
+    return ipaddress.ip_network(str(value), strict=False)
+
+
+def _parse_address(value):
+    if isinstance(value, ct.MapType) and "_ip" in value:
+        return ipaddress.ip_address(str(value["address"]))
+    return ipaddress.ip_address(str(value))
+
+
+def cidr(value):
+    """``cidr("10.0.0.0/8")`` → CIDR object."""
+    net = _parse_network(value)
+    return ct.MapType({
+        "_cidr": True,
+        "cidr": ct.StringType(str(net)),
+        "family": ct.IntType(net.version),
+        "prefixLength": ct.IntType(net.prefixlen),
+    })
+
+
+def isCIDR(value):  # noqa: N802 — CEL identifier
+    """``isCIDR("10.0.0.0/8")`` → bool."""
+    try:
+        _parse_network(value)
+        return ct.BoolType(True)
+    except (ValueError, TypeError):
+        return ct.BoolType(False)
+
+
+def containsIP(net_value, ip_value):  # noqa: N802 — CEL identifier
+    """``cidr.containsIP(ip)`` → bool."""
+    return ct.BoolType(_parse_address(ip_value) in _parse_network(net_value))
+
+
+def containsCIDR(outer, inner):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_parse_network(outer).supernet_of(_parse_network(inner)))
+
+
+def prefixLength(value):  # noqa: N802 — CEL identifier
+    return ct.IntType(_parse_network(value).prefixlen)
+
+
+def masked(value):
+    net = _parse_network(value)
+    # Return canonical (network address) string form.
+    return ct.MapType({
+        "_cidr": True,
+        "cidr": ct.StringType(str(net)),
+        "family": ct.IntType(net.version),
+        "prefixLength": ct.IntType(net.prefixlen),
+    })
+
+
+__all__ = [
+    "cidr",
+    "isCIDR",
+    "containsIP",
+    "containsCIDR",
+    "prefixLength",
+    "masked",
+]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/format_lib.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/format_lib.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: named string formats.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/format.go``. Exposes a
+``format.named("<name>")`` that returns a "matcher" object with a
+``validate(value) -> list[string]`` method (empty list means valid).
+
+celpy doesn't support a real ``format`` namespace, so we expose the
+matcher via the global function ``namedFormat("<name>")`` (which can
+also be called as ``"name".namedFormat()`` per CEL method-call sugar).
+The shape mirrors the K8s API; the regexes are ported verbatim from
+the Go originals listed below.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Mapping
+
+import celpy.celtypes as ct
+
+# ---------------------------------------------------------------------------
+# Named format regexes (ported from k8s.io/apimachinery/pkg/util/validation).
+# ---------------------------------------------------------------------------
+
+DNS1123_LABEL_FMT = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+DNS1123_LABEL_MAX = 63
+DNS1123_LABEL_RE = re.compile(rf"^{DNS1123_LABEL_FMT}$")
+
+DNS1123_SUBDOMAIN_FMT = rf"{DNS1123_LABEL_FMT}(\.{DNS1123_LABEL_FMT})*"
+DNS1123_SUBDOMAIN_MAX = 253
+DNS1123_SUBDOMAIN_RE = re.compile(rf"^{DNS1123_SUBDOMAIN_FMT}$")
+
+DNS1035_LABEL_FMT = r"[a-z]([-a-z0-9]*[a-z0-9])?"
+DNS1035_LABEL_MAX = 63
+DNS1035_LABEL_RE = re.compile(rf"^{DNS1035_LABEL_FMT}$")
+
+QNAME_CHAR_FMT = r"[A-Za-z0-9]"
+QNAME_EXT_CHAR_FMT = r"[-A-Za-z0-9_.]"
+QUALIFIED_NAME_FMT = (
+    rf"({QNAME_CHAR_FMT}{QNAME_EXT_CHAR_FMT}*)?{QNAME_CHAR_FMT}"
+)
+QUALIFIED_NAME_MAX = 63
+QUALIFIED_NAME_RE = re.compile(rf"^{QUALIFIED_NAME_FMT}$")
+
+LABEL_VALUE_FMT = (
+    rf"(({QNAME_CHAR_FMT}{QNAME_EXT_CHAR_FMT}*)?{QNAME_CHAR_FMT})?"
+)
+LABEL_VALUE_MAX = 63
+LABEL_VALUE_RE = re.compile(rf"^{LABEL_VALUE_FMT}$")
+
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+# Liberal subset; full RFC3986 URI is delegated to ``urllib.parse.urlsplit``.
+URI_FORBIDDEN = re.compile(r"[\s<>\"]")
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?"
+    r"([Zz]|[+\-]\d{2}:\d{2})$"
+)
+
+
+def _check_dns1123_label(value: str) -> list[str]:
+    errs: list[str] = []
+    if len(value) > DNS1123_LABEL_MAX:
+        errs.append(f"must be no more than {DNS1123_LABEL_MAX} characters")
+    if not DNS1123_LABEL_RE.match(value):
+        errs.append("a lowercase RFC 1123 label must consist of lower case "
+                    "alphanumeric characters or '-', and must start and end "
+                    "with an alphanumeric character")
+    return errs
+
+
+def _check_dns1123_subdomain(value: str) -> list[str]:
+    errs: list[str] = []
+    if len(value) > DNS1123_SUBDOMAIN_MAX:
+        errs.append(f"must be no more than {DNS1123_SUBDOMAIN_MAX} characters")
+    if not DNS1123_SUBDOMAIN_RE.match(value):
+        errs.append("a lowercase RFC 1123 subdomain must consist of lower "
+                    "case alphanumeric characters, '-' or '.', and must "
+                    "start and end with an alphanumeric character")
+    return errs
+
+
+def _check_dns1035_label(value: str) -> list[str]:
+    errs: list[str] = []
+    if len(value) > DNS1035_LABEL_MAX:
+        errs.append(f"must be no more than {DNS1035_LABEL_MAX} characters")
+    if not DNS1035_LABEL_RE.match(value):
+        errs.append("a DNS-1035 label must consist of lower case alphanumeric "
+                    "characters or '-', start with an alphabetic character, "
+                    "and end with an alphanumeric character")
+    return errs
+
+
+def _check_qualified_name(value: str) -> list[str]:
+    errs: list[str] = []
+    parts = value.split("/")
+    if len(parts) == 1:
+        name = parts[0]
+    elif len(parts) == 2:
+        prefix, name = parts
+        if not prefix:
+            errs.append("prefix part must be non-empty")
+        else:
+            errs.extend("prefix part: " + e for e in _check_dns1123_subdomain(prefix))
+    else:
+        errs.append("a qualified name must consist of alphanumeric characters,"
+                    " '-', '_' or '.', with an optional DNS subdomain prefix and"
+                    " '/'")
+        return errs
+    if not name:
+        errs.append("name part must be non-empty")
+    elif len(name) > QUALIFIED_NAME_MAX:
+        errs.append(f"name part must be no more than {QUALIFIED_NAME_MAX} characters")
+    elif not QUALIFIED_NAME_RE.match(name):
+        errs.append("name part must consist of alphanumeric characters, '-', "
+                    "'_' or '.', and must start and end with an alphanumeric"
+                    " character")
+    return errs
+
+
+def _check_label_value(value: str) -> list[str]:
+    errs: list[str] = []
+    if len(value) > LABEL_VALUE_MAX:
+        errs.append(f"must be no more than {LABEL_VALUE_MAX} characters")
+    if not LABEL_VALUE_RE.match(value):
+        errs.append("a valid label must be an empty string or consist of "
+                    "alphanumeric characters, '-', '_' or '.', and must start"
+                    " and end with an alphanumeric character")
+    return errs
+
+
+def _check_uri(value: str) -> list[str]:
+    if URI_FORBIDDEN.search(value):
+        return ["must not contain whitespace or unsafe characters"]
+    import urllib.parse
+    parsed = urllib.parse.urlsplit(value)
+    if not parsed.scheme:
+        return ["must be a valid URI (no scheme detected)"]
+    return []
+
+
+def _check_uuid(value: str) -> list[str]:
+    return [] if UUID_RE.match(value) else ["must be a valid UUID"]
+
+
+def _check_byte(value: str) -> list[str]:
+    import base64
+    try:
+        base64.b64decode(value, validate=True)
+        return []
+    except (ValueError, TypeError):
+        return ["must be valid base64-encoded data"]
+
+
+def _check_date(value: str) -> list[str]:
+    if not DATE_RE.match(value):
+        return ["must be in YYYY-MM-DD format"]
+    import datetime
+    try:
+        datetime.date.fromisoformat(value)
+        return []
+    except ValueError as e:
+        return [str(e)]
+
+
+def _check_datetime(value: str) -> list[str]:
+    if not DATETIME_RE.match(value):
+        return ["must be a valid RFC3339 datetime"]
+    import datetime
+    try:
+        # Python tolerates 'Z' since 3.11; accept lowercase too.
+        datetime.datetime.fromisoformat(value.replace("Z", "+00:00").replace("z", "+00:00"))
+        return []
+    except ValueError as e:
+        return [str(e)]
+
+
+_CHECKERS: Mapping[str, Callable[[str], list]] = {
+    "dns1123Label": _check_dns1123_label,
+    "dns1123Subdomain": _check_dns1123_subdomain,
+    "dns1035Label": _check_dns1035_label,
+    "qualifiedName": _check_qualified_name,
+    "labelValue": _check_label_value,
+    "uri": _check_uri,
+    "uuid": _check_uuid,
+    "byte": _check_byte,
+    "date": _check_date,
+    "datetime": _check_datetime,
+}
+
+
+def named(name):
+    """``format.named("<n>")`` → matcher.
+
+    The returned matcher is a CEL ``MapType`` carrying a callable
+    ``validate`` reference. We expose validation through the
+    ``validateFormat(matcher, value)`` global function below since
+    celpy does not support attaching arbitrary methods to MapType.
+    """
+    if str(name) not in _CHECKERS:
+        raise ValueError(f"unknown named format: {name!r}")
+    return ct.MapType({"name": ct.StringType(str(name))})
+
+
+def validateFormat(matcher, value):  # noqa: N802 — CEL identifier
+    """``matcher.validate(value)`` (or ``validateFormat(matcher, value)``)
+    returns a list of error strings; empty list means the value is
+    valid for that format."""
+    name = str(matcher["name"])
+    checker = _CHECKERS[name]
+    errs = checker(str(value))
+    return ct.ListType([ct.StringType(e) for e in errs])
+
+
+def namedFormat(name):  # noqa: N802 — CEL identifier
+    """Alias for :func:`named` callable as a member method of strings:
+    ``"dns1123Label".namedFormat()``."""
+    return named(name)
+
+
+__all__ = ["named", "namedFormat", "validateFormat"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/ip_lib.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/ip_lib.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: IP address parsing.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/ip.go``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import celpy.celtypes as ct
+
+
+def _parse(value):
+    if isinstance(value, ct.MapType) and "_ip" in value:
+        return ipaddress.ip_address(str(value["address"]))
+    return ipaddress.ip_address(str(value))
+
+
+def ip(value):
+    """``ip("10.0.0.1")`` → IP address object."""
+    addr = _parse(value)
+    return ct.MapType({
+        "_ip": True,
+        "address": ct.StringType(str(addr)),
+        "family": ct.IntType(addr.version),
+    })
+
+
+def isIP(value):  # noqa: N802 — CEL identifier
+    """``isIP("10.0.0.1")`` → bool. Also callable as a string method."""
+    try:
+        _parse(value)
+        return ct.BoolType(True)
+    except (ValueError, TypeError):
+        return ct.BoolType(False)
+
+
+def family(value):
+    """``ip.family`` shorthand — IP version (4 or 6)."""
+    return ct.IntType(_parse(value).version)
+
+
+def isLoopback(value):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_parse(value).is_loopback)
+
+
+def isUnspecified(value):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_parse(value).is_unspecified)
+
+
+def isLinkLocalUnicast(value):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_parse(value).is_link_local)
+
+
+def isLinkLocalMulticast(value):  # noqa: N802 — CEL identifier
+    addr = _parse(value)
+    return ct.BoolType(addr.is_multicast and addr.is_link_local)
+
+
+def isGlobalUnicast(value):  # noqa: N802 — CEL identifier
+    addr = _parse(value)
+    return ct.BoolType(addr.is_global and not addr.is_multicast)
+
+
+__all__ = [
+    "ip",
+    "isIP",
+    "family",
+    "isLoopback",
+    "isUnspecified",
+    "isLinkLocalUnicast",
+    "isLinkLocalMulticast",
+    "isGlobalUnicast",
+]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/lists.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/lists.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: list operations.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/lists.go`` — provides
+``indexOf``, ``lastIndexOf``, ``min``, ``max``, ``sum`` as method-style
+calls on lists.
+"""
+
+from __future__ import annotations
+
+import celpy.celtypes as ct
+
+
+def indexOf(seq, target):  # noqa: N802 — CEL identifier
+    """``list.indexOf(item)`` — first index where item is found, ``-1`` if absent."""
+    for i, v in enumerate(seq):
+        if v == target:
+            return ct.IntType(i)
+    return ct.IntType(-1)
+
+
+def lastIndexOf(seq, target):  # noqa: N802 — CEL identifier
+    """``list.lastIndexOf(item)`` — last index where item is found, ``-1`` if absent."""
+    last = -1
+    for i, v in enumerate(seq):
+        if v == target:
+            last = i
+    return ct.IntType(last)
+
+
+def min(seq):  # noqa: A001 — CEL identifier
+    """``list.min()`` — smallest item; raises if list is empty."""
+    if not seq:
+        raise ValueError("min() called on empty list")
+    result = seq[0]
+    for v in seq[1:]:
+        if v < result:
+            result = v
+    return result
+
+
+def max(seq):  # noqa: A001 — CEL identifier
+    """``list.max()`` — largest item; raises if list is empty."""
+    if not seq:
+        raise ValueError("max() called on empty list")
+    result = seq[0]
+    for v in seq[1:]:
+        if v > result:
+            result = v
+    return result
+
+
+def sum(seq):  # noqa: A001 — CEL identifier
+    """``list.sum()`` — sum of items; ``0`` for empty list."""
+    if not seq:
+        return ct.IntType(0)
+    total = seq[0]
+    for v in seq[1:]:
+        total = total + v
+    return total
+
+
+__all__ = ["indexOf", "lastIndexOf", "min", "max", "sum"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/optional_lib.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/optional_lib.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL optional type — ``optional.of``, ``optional.none`` + methods.
+
+cel-python doesn't natively expose CEL's ``optional<T>``. K8s's
+``x-kubernetes-validations`` rules use ``optional.of(x)``,
+``optional.none()``, and the member methods ``hasValue()``, ``value()``,
+``orValue(default)`` when ``optionalSelf`` / ``optionalOldSelf`` is
+set. This module provides a minimal, wire-compatible port:
+
+- An ``optional`` sentinel is bound into every activation so
+  ``optional.of(x)`` parses as a method call and celpy resolves it via
+  ``of(optional, x)``.
+- An *optional wrapper* is represented as a ``MapType`` carrying an
+  internal ``_optional`` marker plus ``_hasValue`` / ``_value`` slots.
+- ``of(pkg, value)``, ``none(pkg)``, ``hasValue(opt)``, ``value(opt)``,
+  and ``orValue(opt, default)`` are registered as global functions;
+  celpy rewrites ``obj.method(arg)`` as ``method(obj, arg)`` so the
+  method-call shape is covered.
+
+The evaluator uses :data:`OPTIONAL_SENTINEL` in activations and
+:func:`wrap` / :data:`NONE` to construct wrappers when binding ``self``
+and ``oldSelf`` under optional semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import celpy.celtypes as ct
+
+
+# Sentinel bound into every activation as `optional`.
+OPTIONAL_SENTINEL: ct.MapType = ct.MapType({"_optional_pkg": ct.BoolType(True)})
+
+
+def wrap(value: Any) -> ct.MapType:
+    """Construct a present-value optional wrapper (``optional.of(x)``)."""
+    return ct.MapType({
+        "_optional": ct.BoolType(True),
+        "_hasValue": ct.BoolType(True),
+        "_value": value,
+    })
+
+
+#: Constant empty-optional wrapper (``optional.none()``).
+NONE: ct.MapType = ct.MapType({
+    "_optional": ct.BoolType(True),
+    "_hasValue": ct.BoolType(False),
+    "_value": None,
+})
+
+
+# --------------------------------------------------------------------- CEL
+
+def of(pkg, value):  # noqa: ARG001 — pkg is the `optional` sentinel
+    return wrap(value)
+
+
+def none(pkg):  # noqa: ARG001 — pkg is the `optional` sentinel
+    return NONE
+
+
+def hasValue(opt):  # noqa: N802 — CEL identifier
+    return ct.BoolType(bool(opt.get("_hasValue", False)))
+
+
+def value(opt):
+    if not opt.get("_hasValue"):
+        raise ValueError("optional.value() called on empty optional")
+    return opt["_value"]
+
+
+def orValue(opt, default):  # noqa: N802 — CEL identifier
+    if opt.get("_hasValue"):
+        return opt["_value"]
+    return default
+
+
+__all__ = ["of", "none", "hasValue", "value", "orValue"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/quantity.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/quantity.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: resource quantities.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/quantity.go`` and the
+underlying ``k8s.io/apimachinery/pkg/api/resource.Quantity`` parser.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import celpy.celtypes as ct
+
+# SI suffixes (decimal): 10^N
+_SI_DEC = {
+    "n": Decimal(10) ** -9,
+    "u": Decimal(10) ** -6,
+    "m": Decimal(10) ** -3,
+    "":  Decimal(1),
+    "k": Decimal(10) ** 3,
+    "M": Decimal(10) ** 6,
+    "G": Decimal(10) ** 9,
+    "T": Decimal(10) ** 12,
+    "P": Decimal(10) ** 15,
+    "E": Decimal(10) ** 18,
+}
+
+# Binary suffixes: 2^(10*N)
+_SI_BIN = {
+    "Ki": Decimal(2) ** 10,
+    "Mi": Decimal(2) ** 20,
+    "Gi": Decimal(2) ** 30,
+    "Ti": Decimal(2) ** 40,
+    "Pi": Decimal(2) ** 50,
+    "Ei": Decimal(2) ** 60,
+}
+
+_QUANTITY_RE = re.compile(
+    r"^"
+    r"(?P<sign>[+-]?)"
+    r"(?P<num>\d+(\.\d+)?|\.\d+)"
+    r"(?P<exp>[eE][+-]?\d+)?"
+    r"(?P<unit>Ei|Pi|Ti|Gi|Mi|Ki|[numkMGTPE])?"
+    r"$"
+)
+
+
+class _Quantity:
+    """In-memory representation of a parsed K8s quantity.
+
+    The value is stored as a :class:`decimal.Decimal` for exact
+    arithmetic; suffix info is preserved only to round-trip via
+    ``str(q)`` (not currently used).
+    """
+
+    __slots__ = ("value", "_unit")
+
+    def __init__(self, value: Decimal, unit: str = ""):
+        self.value = value
+        self._unit = unit
+
+    def __repr__(self):
+        return f"_Quantity({self.value}, {self._unit!r})"
+
+
+def _parse(value: str) -> _Quantity:
+    m = _QUANTITY_RE.match(value)
+    if not m:
+        raise ValueError(f"invalid quantity: {value!r}")
+    sign = m.group("sign") or ""
+    num = m.group("num")
+    exp = m.group("exp") or ""
+    unit = m.group("unit") or ""
+
+    base = Decimal(f"{sign}{num}{exp}")
+    if unit in _SI_BIN:
+        multiplier = _SI_BIN[unit]
+    elif unit in _SI_DEC:
+        multiplier = _SI_DEC[unit]
+    else:  # pragma: no cover — regex restricts the inputs
+        raise ValueError(f"unknown quantity unit: {unit!r}")
+    return _Quantity(base * multiplier, unit)
+
+
+def quantity(value):
+    """``quantity("100Mi")`` → quantity object."""
+    if isinstance(value, ct.MapType) and "_quantity" in value:
+        return value
+    parsed = _parse(str(value))
+    return ct.MapType({"_quantity": True, "value": ct.StringType(str(parsed.value))})
+
+
+def isQuantity(value):  # noqa: N802 — CEL identifier
+    """``isQuantity("100Mi")`` → bool. Also callable as method on string."""
+    try:
+        _parse(str(value))
+        return ct.BoolType(True)
+    except ValueError:
+        return ct.BoolType(False)
+
+
+def _value(q) -> Decimal:
+    return Decimal(str(q["value"]))
+
+
+def add(q1, q2):
+    """``q1.add(q2)`` (or ``add(q1, q2)``) → quantity sum."""
+    total = _value(q1) + _value(q2)
+    return ct.MapType({"_quantity": True, "value": ct.StringType(str(total))})
+
+
+def sub(q1, q2):
+    total = _value(q1) - _value(q2)
+    return ct.MapType({"_quantity": True, "value": ct.StringType(str(total))})
+
+
+def isLessThan(q1, q2):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_value(q1) < _value(q2))
+
+
+def isGreaterThan(q1, q2):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_value(q1) > _value(q2))
+
+
+def compareTo(q1, q2):  # noqa: N802 — CEL identifier
+    a, b = _value(q1), _value(q2)
+    if a < b:
+        return ct.IntType(-1)
+    if a > b:
+        return ct.IntType(1)
+    return ct.IntType(0)
+
+
+def asInteger(q):  # noqa: N802 — CEL identifier
+    """``q.asInteger()`` — truncates toward zero, errors on overflow."""
+    val = _value(q)
+    truncated = int(val)
+    if truncated.bit_length() > 63:
+        raise OverflowError("quantity does not fit in int64")
+    return ct.IntType(truncated)
+
+
+def asApproximateFloat(q):  # noqa: N802 — CEL identifier
+    return ct.DoubleType(float(_value(q)))
+
+
+def isInteger(q):  # noqa: N802 — CEL identifier
+    return ct.BoolType(_value(q) == _value(q).to_integral_value())
+
+
+def sign(q):
+    val = _value(q)
+    if val > 0:
+        return ct.IntType(1)
+    if val < 0:
+        return ct.IntType(-1)
+    return ct.IntType(0)
+
+
+__all__ = [
+    "quantity",
+    "isQuantity",
+    "add",
+    "sub",
+    "isLessThan",
+    "isGreaterThan",
+    "compareTo",
+    "asInteger",
+    "asApproximateFloat",
+    "isInteger",
+    "sign",
+]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/regex_lib.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/extensions/regex_lib.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""K8s CEL extension library: regex.
+
+Mirrors ``k8s.io/apiserver/pkg/cel/library/regex.go`` — provides
+``find`` and ``findAll`` as string member methods.
+
+K8s uses google-re2 (RE2) for regex; the Python port relies on the
+``re`` stdlib module. The two engines disagree on a small number of
+edge cases (named-group syntax, possessive quantifiers, lookarounds);
+patterns produced by Kubernetes contributors typically stay within the
+RE2 subset, so this is rarely an issue in practice.
+"""
+
+from __future__ import annotations
+
+import re
+
+import celpy.celtypes as ct
+
+
+def find(s, pattern):
+    """``str.find(pattern)`` — first match or empty string if no match."""
+    m = re.search(str(pattern), str(s))
+    return ct.StringType(m.group(0)) if m else ct.StringType("")
+
+
+def findAll(s, pattern, *limit):  # noqa: N802 — CEL identifier
+    """``str.findAll(pattern[, limit])`` — list of matches; optional limit."""
+    matches = re.findall(str(pattern), str(s))
+    if limit:
+        matches = matches[: int(limit[0])]
+    # findall returns tuples for grouped patterns — flatten to plain strings.
+    out = ct.ListType()
+    for m in matches:
+        if isinstance(m, tuple):
+            out.append(ct.StringType(m[0] if m else ""))
+        else:
+            out.append(ct.StringType(m))
+    return out
+
+
+__all__ = ["find", "findAll"]

--- a/src/main/python/kubernator/plugins/k8s_schema/cel/rules.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/cel/rules.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""Walks an OpenAPI v3 schema collecting ``x-kubernetes-validations``
+rules together with the manifest paths they apply to.
+
+The walker yields one entry per rule:
+
+    (manifest_path, rule_dict)
+
+where ``manifest_path`` is a list of segments — each segment is either
+a string property name or the sentinel :data:`ARRAY_ITEM` marking
+descent into a list item (the actual index is supplied by the
+evaluator at value lookup time). Rules attached to a schema apply to
+the value at that path.
+
+The walker does **not** compile rule expressions; compilation happens
+lazily inside the evaluator on first use.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Mapping
+
+
+# Sentinel for "any list item" in the dotted-path used by collect_rules.
+ARRAY_ITEM = object()
+
+
+def _rules_at(schema: Mapping) -> list:
+    rules = schema.get("x-kubernetes-validations")
+    if not rules:
+        return []
+    if isinstance(rules, Mapping):  # tolerate single-rule shorthand
+        return [rules]
+    return list(rules)
+
+
+def collect_rules(schema: Mapping) -> Iterator[tuple[list[Any], dict]]:
+    """Yield ``(path, rule)`` tuples for every CEL validation rule in
+    *schema*. Recurses through ``properties``, ``items``,
+    ``additionalProperties``, and the composition keywords
+    (``allOf``/``oneOf``/``anyOf``)."""
+    yield from _walk(schema, [])
+
+
+def _walk(schema: Any, path: list[Any]) -> Iterator[tuple[list[Any], dict]]:
+    if not isinstance(schema, Mapping):
+        return
+
+    for rule in _rules_at(schema):
+        yield (list(path), rule)
+
+    properties = schema.get("properties")
+    if isinstance(properties, Mapping):
+        for name, sub in properties.items():
+            yield from _walk(sub, path + [name])
+
+    items = schema.get("items")
+    if isinstance(items, Mapping):
+        yield from _walk(items, path + [ARRAY_ITEM])
+
+    additional = schema.get("additionalProperties")
+    if isinstance(additional, Mapping):
+        # Map values: rule applies to each map value; path semantics
+        # mirror an array item (the evaluator iterates).
+        yield from _walk(additional, path + [ARRAY_ITEM])
+
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        branches = schema.get(keyword)
+        if isinstance(branches, list):
+            for branch in branches:
+                yield from _walk(branch, path)
+
+
+def resolve_path(value: Any, path: list[Any]) -> Iterator[Any]:
+    """Yield every value reachable in *value* by descending *path*.
+    For string segments, yields the named property's value; for
+    :data:`ARRAY_ITEM`, yields each list element (or each map value
+    when the parent is a dict — covers ``additionalProperties``)."""
+    if not path:
+        yield value
+        return
+    head, tail = path[0], path[1:]
+    if head is ARRAY_ITEM:
+        if isinstance(value, list):
+            for item in value:
+                yield from resolve_path(item, tail)
+        elif isinstance(value, Mapping):
+            for v in value.values():
+                yield from resolve_path(v, tail)
+        return
+    if isinstance(value, Mapping) and head in value:
+        yield from resolve_path(value[head], tail)
+
+
+def format_path(path: list[Any]) -> str:
+    """Render *path* as a dotted string like ``$.spec.containers[*].image``
+    suitable for inclusion in error messages."""
+    out = ["$"]
+    for seg in path:
+        if seg is ARRAY_ITEM:
+            out.append("[*]")
+        else:
+            out.append(f".{seg}")
+    return "".join(out)

--- a/src/main/python/kubernator/plugins/k8s_schema/sources.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/sources.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+from typing import Mapping, Optional
+
+from kubernator.api import FileType, load_remote_file
+
+logger = logging.getLogger("kubernator.k8s_schema.sources")
+
+
+GITHUB_V3_LIST_URL = (
+    "https://api.github.com/repos/kubernetes/kubernetes/contents/"
+    "api/openapi-spec/v3?ref={ref}"
+)
+GITHUB_V3_RAW_URL = (
+    "https://raw.githubusercontent.com/kubernetes/kubernetes/"
+    "{ref}/api/openapi-spec/v3/{name}"
+)
+
+
+def _gv_path_to_filename(gv_path: str) -> str:
+    """`api/v1` -> `api__v1_openapi.json`,
+    `apis/apps/v1` -> `apis__apps__v1_openapi.json`.
+    """
+    return gv_path.replace("/", "__") + "_openapi.json"
+
+
+def _filename_to_gv_path(filename: str) -> Optional[str]:
+    """Inverse of :func:`_gv_path_to_filename`. Returns ``None`` for files
+    whose names don't conform to the expected pattern."""
+    if not filename.endswith("_openapi.json"):
+        return None
+    base = filename[:-len("_openapi.json")]
+    return base.replace("__", "/")
+
+
+class ClusterSource:
+    """Fetches the OpenAPI v3 discovery index and per-group documents
+    directly from a Kubernetes cluster via the embedded ``ApiClient``.
+
+    The discovery endpoint is ``/openapi/v3``; sub-documents are referenced
+    by their ``serverRelativeURL`` (which embeds a content hash, so
+    in-memory caching is sufficient).
+    """
+
+    name = "cluster"
+
+    def __init__(self, api_client):
+        self.api_client = api_client
+
+    def fetch_index(self) -> Mapping[str, str]:
+        resp = self.api_client.call_api(
+            resource_path="/openapi/v3",
+            method="GET",
+            auth_settings=["BearerToken"],
+            _preload_content=False,
+            _return_http_data_only=True,
+        )
+        data = json.loads(resp.data)
+        return {gv_path: entry["serverRelativeURL"]
+                for gv_path, entry in data["paths"].items()}
+
+    def fetch_document(self, key: str, locator: str) -> Mapping:
+        # locator is the serverRelativeURL — split into path/query for call_api.
+        parsed = urllib.parse.urlsplit(locator)
+        query_params = urllib.parse.parse_qsl(parsed.query)
+        resp = self.api_client.call_api(
+            resource_path=parsed.path,
+            method="GET",
+            query_params=query_params,
+            auth_settings=["BearerToken"],
+            _preload_content=False,
+            _return_http_data_only=True,
+        )
+        return json.loads(resp.data)
+
+
+class GitHubSource:
+    """Fetches OpenAPI v3 documents from kubernetes/kubernetes on GitHub
+    at the cluster's git tag. Used as a fallback when the cluster's
+    discovery endpoint is unavailable."""
+
+    name = "github"
+
+    def __init__(self, git_version: str):
+        # git_version is the leading-`v` form (e.g. ``v1.30.2``)
+        self.git_version = git_version
+
+    def fetch_index(self) -> Mapping[str, str]:
+        listing_url = GITHUB_V3_LIST_URL.format(ref=self.git_version)
+        listing = load_remote_file(logger, listing_url, FileType.JSON,
+                                   sub_category="openapi_v3_index")
+        # GitHub returns either a list of dicts or a single dict
+        entries = listing if isinstance(listing, list) else [listing]
+        index: dict[str, str] = {}
+        for entry in entries:
+            name = entry.get("name")
+            if not name:
+                continue
+            gv_path = _filename_to_gv_path(name)
+            if gv_path is None:
+                continue
+            index[gv_path] = name
+        return index
+
+    def fetch_document(self, key: str, locator: str) -> Mapping:
+        url = GITHUB_V3_RAW_URL.format(ref=self.git_version, name=locator)
+        return load_remote_file(logger, url, FileType.JSON,
+                                sub_category="openapi_v3")

--- a/src/main/python/kubernator/plugins/k8s_schema/v2.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/v2.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+from typing import Optional
+
+from jsonschema._keywords import required
+from jsonschema.exceptions import ValidationError
+from jsonschema.validators import extend
+# Why OAS31Validator (not OAS30) for Kubernetes swagger.json:
+# K8s swagger.json has hundreds of `$ref` nodes with sibling keywords
+# (mostly `description`, plus `x-kubernetes-*` extensions and the
+# `JSONSchemaProps` meta-def). OpenAPI 3.0 mandates ignoring siblings
+# on `$ref`, which OAS30Validator enforces and which destroys those
+# docs. JSON Schema 2020-12 / OpenAPI 3.1 honors `$ref` siblings, so
+# OAS31Validator is the only viable base for v2 swagger validation.
+from openapi_schema_validator import OAS31Validator
+
+from kubernator.api import FileType, load_remote_file
+from kubernator.plugins.k8s_api import (K8SResourceDef,
+                                        K8SResourceDefKey,
+                                        to_group_and_version)
+from kubernator.plugins.k8s_schema.base import (OpenAPIValidator,
+                                                extract_gvk_keys,
+                                                k8s_format_checker,
+                                                type_validator)
+
+logger = logging.getLogger("kubernator.k8s_schema.v2")
+
+
+K8SValidator = extend(OAS31Validator, validators={
+    "type": type_validator,
+    "required": required
+})
+
+
+class SwaggerV2Validator(OpenAPIValidator):
+    """Loads Kubernetes OpenAPI v2 (swagger.json) from GitHub and validates
+    manifests against it. Preserves the pre-refactor behavior."""
+
+    version = "v2"
+
+    def __init__(self, context):
+        self.context = context
+        self.resource_definitions: MutableMapping[K8SResourceDefKey, K8SResourceDef] = {}
+        self.resource_paths: MutableMapping[K8SResourceDefKey, MutableMapping[str, dict]] = {}
+        self.resource_definitions_schema: Optional[Mapping] = None
+
+    def load(self) -> None:
+        k8s = self.context.k8s
+        logger.debug("Reading Kubernetes OpenAPI v2 spec for %s", k8s.server_git_version)
+        k8s_def = load_remote_file(
+            logger,
+            f"https://raw.githubusercontent.com/kubernetes/kubernetes/"
+            f"{k8s.server_git_version}/api/openapi-spec/swagger.json",
+            FileType.JSON)
+        self.resource_definitions_schema = k8s_def
+        self._populate_resource_definitions()
+
+    def iter_errors(
+            self,
+            manifest: Mapping,
+            rdef: K8SResourceDef,
+            *,
+            old_manifest: Optional[Mapping] = None,
+    ) -> Iterator[ValidationError]:
+        # old_manifest is accepted for API parity with v3 (transition rules);
+        # v2 built-in schemas carry no x-kubernetes-validations so it's ignored.
+        validator = K8SValidator(rdef.schema, format_checker=k8s_format_checker)
+        yield from validator.iter_errors(manifest)
+
+    def api_versions(self) -> Iterable[str]:
+        api_versions: set[str] = set()
+        for key in self.resource_definitions:
+            api_version = f"{f'{key.group}/' if key.group else ''}{key.version}"
+            api_versions.add(api_version)
+        return sorted(api_versions)
+
+    def _populate_resource_definitions(self) -> None:
+        k8s_def = self.resource_definitions_schema
+        paths = k8s_def["paths"]
+        for path, actions in paths.items():
+            path_rdk = None
+            path_actions: list[str] = []
+            for action, action_details in actions.items():
+                if action == "parameters":
+                    continue
+                rdks = list(extract_gvk_keys(action_details))
+                if rdks:
+                    assert len(rdks) == 1
+                    rdk = rdks[0]
+                    if path_rdk:
+                        if path_rdk != rdk:
+                            raise ValueError(
+                                f"Encountered path action x-kubernetes-group-version-kind conflict: "
+                                f"{path}: {actions}")
+                        path_actions.append(action_details["x-kubernetes-action"])
+                    else:
+                        path_rdk = rdk
+
+            if path_rdk:
+                rdef_paths = self.resource_paths.setdefault(path_rdk, {})
+                rdef_paths[path] = actions
+
+        for k, schema in k8s_def["definitions"].items():
+            # short-circuit ref resolution to the top of the document
+            schema["definitions"] = k8s_def["definitions"]
+            for key in extract_gvk_keys(schema):
+                for rdef in K8SResourceDef.from_manifest(key, schema, self.resource_paths):
+                    self.resource_definitions[key] = rdef
+
+
+# re-export for factory/consumer convenience
+__all__ = [
+    "SwaggerV2Validator",
+    "K8SValidator",
+    "to_group_and_version",
+]

--- a/src/main/python/kubernator/plugins/k8s_schema/v3.py
+++ b/src/main/python/kubernator/plugins/k8s_schema/v3.py
@@ -1,0 +1,438 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+from typing import Any, Optional
+
+from jsonschema._keywords import required
+from jsonschema.exceptions import ValidationError
+from jsonschema.validators import extend
+from openapi_schema_validator import OAS30Validator
+
+from kubernator.plugins.k8s_api import (K8SResourceDef,
+                                        K8SResourceDefKey,
+                                        to_group_and_version)
+from kubernator.plugins.k8s_schema.base import (OpenAPIValidator,
+                                                extract_gvk_keys,
+                                                k8s_format_checker,
+                                                type_validator)
+from kubernator.plugins.k8s_schema.cel import CELEvaluator
+
+logger = logging.getLogger("kubernator.k8s_schema.v3")
+
+
+# Matches OpenAPI v3 group-version-path keys published by Kubernetes:
+#   api/v1
+#   apis/<group>/<version>   (group may itself contain dots, e.g. apps,
+#                             apiextensions.k8s.io)
+_GV_PATH_RE = re.compile(r"^(api|apis/[^/]+)/[^/]+$")
+
+
+def _gv_path_to_api_version(gv_path: str) -> Optional[str]:
+    """``api/v1`` → ``v1``, ``apis/apps/v1`` → ``apps/v1``."""
+    if gv_path.startswith("api/"):
+        return gv_path[len("api/"):]
+    if gv_path.startswith("apis/"):
+        return gv_path[len("apis/"):]
+    return None
+
+
+def _api_version_to_gv_path(api_version: str) -> str:
+    if "/" not in api_version:
+        return f"api/{api_version}"
+    return f"apis/{api_version}"
+
+
+def _ref_name(ref: str) -> Optional[str]:
+    if not isinstance(ref, str):
+        return None
+    if ref.startswith("#/components/schemas/"):
+        return ref[len("#/components/schemas/"):]
+    return None
+
+
+def _walk_refs(schema: Any) -> Iterator[str]:
+    if isinstance(schema, Mapping):
+        if "$ref" in schema:
+            name = _ref_name(schema["$ref"])
+            if name:
+                yield name
+        for v in schema.values():
+            yield from _walk_refs(v)
+    elif isinstance(schema, list):
+        for v in schema:
+            yield from _walk_refs(v)
+
+
+def _owning_gv_paths(ref_name: str, index_keys: Iterable[str]) -> list[str]:
+    """Map a ``$ref`` name (e.g. ``io.k8s.api.apps.v1.Deployment``) back to
+    the group-version path(s) that could hold it, using the discovery
+    index as a ground-truth enumeration."""
+    index_list = list(index_keys)
+
+    if ref_name.startswith("io.k8s.api.core.v1."):
+        return ["api/v1"]
+
+    if ref_name.startswith("io.k8s.api."):
+        parts = ref_name[len("io.k8s.api."):].split(".")
+        # "<group-parts>.<version>.<Kind>": version and Kind are the last two.
+        if len(parts) >= 3:
+            version = parts[-2]
+            group_parts = parts[:-2]
+            group = ".".join(group_parts)
+            candidate = f"apis/{group}/{version}"
+            if candidate in index_list:
+                return [candidate]
+
+    # apimachinery and any ref we can't pin down: probe the entire index
+    # in a stable order (core first, then alphabetical). The fetcher will
+    # merge whichever document contains the definition.
+    ordered = []
+    if "api/v1" in index_list:
+        ordered.append("api/v1")
+    for p in sorted(index_list):
+        if p == "api/v1":
+            continue
+        ordered.append(p)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# Custom keyword handlers for Kubernetes extensions
+# ---------------------------------------------------------------------------
+
+_orig_additional_properties = OAS30Validator.VALIDATORS["additionalProperties"]
+
+
+def _hashable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(sorted((k, _hashable(v)) for k, v in value.items()))
+    if isinstance(value, list):
+        return tuple(_hashable(v) for v in value)
+    return value
+
+
+def list_type_validator(validator, list_type, instance, schema):
+    if list_type == "atomic":
+        return
+    if not isinstance(instance, list):
+        return
+    if list_type == "set":
+        seen: set = set()
+        for idx, item in enumerate(instance):
+            key = _hashable(item)
+            if key in seen:
+                yield ValidationError(
+                    f"item at index {idx} duplicates an earlier item "
+                    f"(x-kubernetes-list-type: set)")
+                continue
+            seen.add(key)
+        return
+    if list_type == "map":
+        keys = schema.get("x-kubernetes-list-map-keys") or []
+        if not keys:
+            return
+        seen_keys: set = set()
+        for idx, item in enumerate(instance):
+            if not isinstance(item, dict):
+                yield ValidationError(
+                    f"item at index {idx} is not an object "
+                    f"(x-kubernetes-list-type: map requires object items)")
+                continue
+            missing = [k for k in keys if k not in item]
+            if missing:
+                yield ValidationError(
+                    f"item at index {idx} is missing x-kubernetes-list-map "
+                    f"key(s) {missing}")
+                continue
+            key_tuple = tuple(_hashable(item[k]) for k in keys)
+            if key_tuple in seen_keys:
+                yield ValidationError(
+                    f"item at index {idx} duplicates map keys {keys} of an "
+                    f"earlier item")
+                continue
+            seen_keys.add(key_tuple)
+
+
+def additional_properties_validator(validator, ap, instance, schema):
+    if schema.get("x-kubernetes-preserve-unknown-fields") is True:
+        return
+    if schema.get("x-kubernetes-embedded-resource") is True:
+        return
+    yield from _orig_additional_properties(validator, ap, instance, schema)
+
+
+def preserve_unknown_fields_validator(validator, flag, instance, schema):
+    # The actual effect lives in additional_properties_validator above;
+    # this handler exists so the keyword is recognized (not "unknown").
+    return
+    yield  # pragma: no cover — keep generator contract
+
+
+def embedded_resource_validator(validator, flag, instance, schema):
+    if flag is not True:
+        return
+    if not isinstance(instance, dict):
+        yield ValidationError(
+            "x-kubernetes-embedded-resource expects an object")
+        return
+    if "apiVersion" not in instance:
+        yield ValidationError("embedded resource is missing 'apiVersion'")
+    if "kind" not in instance:
+        yield ValidationError("embedded resource is missing 'kind'")
+    metadata = instance.get("metadata")
+    if isinstance(metadata, dict):
+        name = metadata.get("name")
+        if name is not None:
+            from kubernator.plugins.k8s_schema.cel.extensions.format_lib import (
+                _check_dns1123_subdomain,
+            )
+            errs = _check_dns1123_subdomain(str(name))
+            for e in errs:
+                yield ValidationError(f"embedded resource metadata.name {e}")
+
+
+V3ValidatorCls = extend(OAS30Validator, validators={
+    "type": type_validator,
+    "required": required,
+    "x-kubernetes-list-type": list_type_validator,
+    "additionalProperties": additional_properties_validator,
+    "x-kubernetes-preserve-unknown-fields": preserve_unknown_fields_validator,
+    "x-kubernetes-embedded-resource": embedded_resource_validator,
+})
+
+
+# ---------------------------------------------------------------------------
+# Lazy resource-definitions map
+# ---------------------------------------------------------------------------
+
+
+class _LazyResourceDefinitions(MutableMapping):
+    """Dict-like mapping whose missed lookups trigger *load_group* for the
+    key's (group, version)."""
+
+    def __init__(self, load_group):
+        self._load_group = load_group
+        self._data: dict[K8SResourceDefKey, K8SResourceDef] = {}
+
+    def __getitem__(self, key: K8SResourceDefKey) -> K8SResourceDef:
+        try:
+            return self._data[key]
+        except KeyError:
+            pass
+        self._load_group(key.group, key.version)
+        return self._data[key]
+
+    def __setitem__(self, key: K8SResourceDefKey, value: K8SResourceDef):
+        self._data[key] = value
+
+    def __delitem__(self, key: K8SResourceDefKey):
+        del self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __contains__(self, key):
+        return key in self._data
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class OpenAPIV3Validator(OpenAPIValidator):
+    """OpenAPI v3 validator with lazy per-group fetch, transitive ``$ref``
+    resolution across group documents, K8s extension enforcement, and
+    CEL rule evaluation."""
+
+    version = "v3"
+
+    def __init__(self, context, sources: list):
+        self.context = context
+        self.sources = list(sources)
+        self.resource_definitions = _LazyResourceDefinitions(self._ensure_group_loaded)
+        self.resource_paths: MutableMapping[K8SResourceDefKey, MutableMapping[str, dict]] = {}
+
+        self._index: dict[str, str] = {}
+        self._active_source = None
+        self._loaded_groups: set[str] = set()
+        self._scanned_for_refs: set[str] = set()
+        self._components_schemas: dict[str, dict] = {}
+        self._injected_schema_cache: dict[int, dict] = {}
+        self._cel_evaluator = CELEvaluator()
+
+    # ------------------------------------------------------------------ load
+
+    def load(self) -> None:
+        errors: list[Exception] = []
+        for source in self.sources:
+            try:
+                logger.debug("Fetching OpenAPI v3 index via %s", source.name)
+                self._index = dict(source.fetch_index())
+                self._active_source = source
+                logger.info("Loaded OpenAPI v3 discovery index (%d group-versions) "
+                            "via %s", len(self._index), source.name)
+                return
+            except Exception as e:  # noqa: BLE001
+                logger.warning("OpenAPI v3 index fetch via %s failed: %s",
+                               source.name, e)
+                errors.append(e)
+        raise RuntimeError(
+            "Failed to fetch OpenAPI v3 discovery index from any configured source"
+        ) from (errors[-1] if errors else None)
+
+    # ------------------------------------------------------------------ api
+
+    def api_versions(self) -> Iterable[str]:
+        """Reads from the discovery index directly — no sub-document fetch."""
+        out: set[str] = set()
+        for gv_path in self._index:
+            api_version = _gv_path_to_api_version(gv_path)
+            if api_version is not None:
+                out.add(api_version)
+        return sorted(out)
+
+    def iter_errors(self,
+                    manifest: Mapping,
+                    rdef: K8SResourceDef,
+                    *,
+                    old_manifest: Optional[Mapping] = None,
+                    ) -> Iterator[ValidationError]:
+        schema = self._inject_components(rdef.schema)
+        validator = V3ValidatorCls(schema, format_checker=k8s_format_checker)
+        yield from validator.iter_errors(manifest)
+        yield from self._cel_evaluator.iter_rule_errors(
+            manifest, rdef.schema, old_manifest=old_manifest)
+
+    # ------------------------------------------------------------------ lazy fetch
+
+    def _ensure_group_loaded(self, group: str, version: str) -> None:
+        api_version = f"{group}/{version}" if group else version
+        gv_path = _api_version_to_gv_path(api_version)
+        if gv_path in self._loaded_groups:
+            return
+        if gv_path not in self._index:
+            raise KeyError(f"Kubernetes group {api_version!r} not found in OpenAPI v3 "
+                           f"discovery index")
+        self._populate_group(gv_path)
+
+    def _populate_group(self, gv_path: str) -> None:
+        if self._active_source is None:
+            raise RuntimeError("OpenAPIV3Validator.load() was not called")
+        locator = self._index[gv_path]
+        logger.debug("Loading OpenAPI v3 document %s via %s",
+                     gv_path, self._active_source.name)
+        document = self._active_source.fetch_document(gv_path, locator)
+        self._loaded_groups.add(gv_path)
+
+        components = document.get("components") or {}
+        schemas = components.get("schemas") or {}
+        self._components_schemas.update(schemas)
+
+        paths = document.get("paths") or {}
+        self._populate_from_paths(paths)
+        self._populate_from_components(schemas)
+        self._resolve_refs()
+
+    def _populate_from_paths(self, paths: Mapping) -> None:
+        for path, path_entry in paths.items():
+            if not isinstance(path_entry, Mapping):
+                continue
+            path_rdk = None
+            for action_details in path_entry.values():
+                if not isinstance(action_details, Mapping):
+                    continue
+                for rdk in extract_gvk_keys(action_details):
+                    if path_rdk is None:
+                        path_rdk = rdk
+                    elif path_rdk != rdk:
+                        raise ValueError(
+                            f"Encountered path action x-kubernetes-group-version-kind "
+                            f"conflict: {path}: {path_entry}")
+            if path_rdk:
+                rdef_paths = self.resource_paths.setdefault(path_rdk, {})
+                rdef_paths[path] = dict(path_entry)
+
+    def _populate_from_components(self, schemas: Mapping) -> None:
+        for schema in schemas.values():
+            if not isinstance(schema, Mapping):
+                continue
+            for key in extract_gvk_keys(schema):
+                for rdef in K8SResourceDef.from_manifest(key, dict(schema),
+                                                         self.resource_paths):
+                    self.resource_definitions[key] = rdef
+
+    def _resolve_refs(self) -> None:
+        """Scan schemas that haven't been walked yet for cross-document
+        ``$ref``s, pull their owning groups from the discovery index,
+        and loop until the component graph is closed."""
+        while True:
+            unresolved: set[str] = set()
+            pending = [name for name in self._components_schemas
+                       if name not in self._scanned_for_refs]
+            if not pending:
+                return
+            for name in pending:
+                for ref in _walk_refs(self._components_schemas[name]):
+                    if ref not in self._components_schemas:
+                        unresolved.add(ref)
+                self._scanned_for_refs.add(name)
+
+            if not unresolved:
+                return
+
+            for ref in unresolved:
+                for candidate in _owning_gv_paths(ref, self._index.keys()):
+                    if candidate in self._loaded_groups:
+                        continue
+                    self._populate_group(candidate)
+                    if ref in self._components_schemas:
+                        break
+
+    def _inject_components(self, schema: Mapping) -> dict:
+        """Return a copy of *schema* with ``components.schemas`` pointing
+        at the cumulative store so OAS30Validator's local ``$ref``
+        resolver finds cross-document definitions. Cached per schema
+        object so repeated validations on the same rdef don't re-copy."""
+        cached = self._injected_schema_cache.get(id(schema))
+        if cached is not None:
+            return cached
+        out = dict(schema)
+        components = dict(out.get("components") or {})
+        components["schemas"] = self._components_schemas
+        out["components"] = components
+        self._injected_schema_cache[id(schema)] = out
+        return out
+
+
+__all__ = [
+    "OpenAPIV3Validator",
+    "V3ValidatorCls",
+    "_gv_path_to_api_version",
+    "_api_version_to_gv_path",
+    "_owning_gv_paths",
+    "to_group_and_version",
+]

--- a/src/unittest/python/k8s_schema_cel_format_lib_tests.py
+++ b/src/unittest/python/k8s_schema_cel_format_lib_tests.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+import celpy.celtypes as ct
+
+from kubernator.plugins.k8s_schema.cel.extensions.format_lib import (
+    _check_byte,
+    _check_date,
+    _check_datetime,
+    _check_dns1035_label,
+    _check_dns1123_label,
+    _check_dns1123_subdomain,
+    _check_label_value,
+    _check_qualified_name,
+    _check_uri,
+    _check_uuid,
+    named,
+    namedFormat,
+    validateFormat,
+)
+
+
+class DNS1123LabelTest(unittest.TestCase):
+    def test_valid_label(self):
+        self.assertEqual(_check_dns1123_label("my-app"), [])
+        self.assertEqual(_check_dns1123_label("a"), [])
+
+    def test_too_long(self):
+        errs = _check_dns1123_label("a" * 64)
+        self.assertTrue(any("63" in e for e in errs))
+
+    def test_invalid_chars(self):
+        errs = _check_dns1123_label("Bad_Name")
+        self.assertTrue(errs)
+
+    def test_starts_with_dash(self):
+        errs = _check_dns1123_label("-starts-bad")
+        self.assertTrue(errs)
+
+
+class DNS1123SubdomainTest(unittest.TestCase):
+    def test_valid_subdomain(self):
+        self.assertEqual(_check_dns1123_subdomain("my.app.example.com"), [])
+        self.assertEqual(_check_dns1123_subdomain("simple"), [])
+
+    def test_too_long(self):
+        errs = _check_dns1123_subdomain("a" * 254)
+        self.assertTrue(any("253" in e for e in errs))
+
+    def test_invalid_chars(self):
+        errs = _check_dns1123_subdomain("Bad_Name.example.com")
+        self.assertTrue(errs)
+
+
+class DNS1035LabelTest(unittest.TestCase):
+    def test_valid_label(self):
+        self.assertEqual(_check_dns1035_label("my-app"), [])
+        self.assertEqual(_check_dns1035_label("a"), [])
+
+    def test_too_long(self):
+        errs = _check_dns1035_label("a" * 64)
+        self.assertTrue(any("63" in e for e in errs))
+
+    def test_starts_with_digit(self):
+        errs = _check_dns1035_label("1startsdigit")
+        self.assertTrue(errs)
+
+
+class QualifiedNameTest(unittest.TestCase):
+    def test_simple_name(self):
+        self.assertEqual(_check_qualified_name("my-name"), [])
+
+    def test_prefixed_name(self):
+        self.assertEqual(_check_qualified_name("example.com/my-name"), [])
+
+    def test_multiple_slashes(self):
+        errs = _check_qualified_name("a/b/c")
+        self.assertTrue(errs)
+
+    def test_empty_prefix(self):
+        errs = _check_qualified_name("/my-name")
+        self.assertTrue(any("prefix" in e for e in errs))
+
+    def test_empty_name_part(self):
+        errs = _check_qualified_name("example.com/")
+        self.assertTrue(any("name part" in e for e in errs))
+
+    def test_name_too_long(self):
+        errs = _check_qualified_name("a" * 64)
+        self.assertTrue(any("63" in e for e in errs))
+
+    def test_name_invalid_chars(self):
+        errs = _check_qualified_name("name with spaces")
+        self.assertTrue(errs)
+
+
+class LabelValueTest(unittest.TestCase):
+    def test_valid_value(self):
+        self.assertEqual(_check_label_value("my-label_value.1"), [])
+        self.assertEqual(_check_label_value(""), [])
+
+    def test_too_long(self):
+        errs = _check_label_value("a" * 64)
+        self.assertTrue(any("63" in e for e in errs))
+
+    def test_invalid_chars(self):
+        errs = _check_label_value("bad value!")
+        self.assertTrue(errs)
+
+
+class URITest(unittest.TestCase):
+    def test_valid_uri(self):
+        self.assertEqual(_check_uri("https://example.com/path"), [])
+        self.assertEqual(_check_uri("http://example.com"), [])
+
+    def test_forbidden_chars(self):
+        errs = _check_uri("https://example.com/bad path")
+        self.assertTrue(errs)
+
+    def test_no_scheme(self):
+        errs = _check_uri("example.com/path")
+        self.assertTrue(any("scheme" in e for e in errs))
+
+
+class UUIDTest(unittest.TestCase):
+    def test_valid_uuid(self):
+        self.assertEqual(_check_uuid("550e8400-e29b-41d4-a716-446655440000"), [])
+
+    def test_invalid_uuid(self):
+        errs = _check_uuid("not-a-uuid")
+        self.assertTrue(errs)
+
+
+class ByteTest(unittest.TestCase):
+    def test_valid_base64(self):
+        self.assertEqual(_check_byte("SGVsbG8="), [])
+
+    def test_invalid_base64(self):
+        errs = _check_byte("not-valid-base64!!!")
+        self.assertTrue(errs)
+
+
+class DateTest(unittest.TestCase):
+    def test_valid_date(self):
+        self.assertEqual(_check_date("2026-04-18"), [])
+
+    def test_invalid_format(self):
+        errs = _check_date("04/18/2026")
+        self.assertTrue(errs)
+
+    def test_invalid_date_values(self):
+        errs = _check_date("2026-02-30")
+        self.assertTrue(errs)
+
+
+class DateTimeTest(unittest.TestCase):
+    def test_valid_datetime_z(self):
+        self.assertEqual(_check_datetime("2026-04-18T12:00:00Z"), [])
+
+    def test_valid_datetime_offset(self):
+        self.assertEqual(_check_datetime("2026-04-18T12:00:00+05:00"), [])
+
+    def test_valid_datetime_fractional(self):
+        self.assertEqual(_check_datetime("2026-04-18T12:00:00.123Z"), [])
+
+    def test_invalid_format(self):
+        errs = _check_datetime("2026-04-18 12:00:00")
+        self.assertTrue(errs)
+
+
+class NamedFormatAPITest(unittest.TestCase):
+    def test_named_returns_map(self):
+        result = named(ct.StringType("dns1123Label"))
+        self.assertIsInstance(result, ct.MapType)
+        self.assertEqual(str(result["name"]), "dns1123Label")
+
+    def test_named_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            named(ct.StringType("nonExistentFormat"))
+
+    def test_namedFormat_is_alias(self):
+        result = namedFormat(ct.StringType("uuid"))
+        self.assertIsInstance(result, ct.MapType)
+
+    def test_validateFormat_valid(self):
+        matcher = named(ct.StringType("dns1123Label"))
+        errs = validateFormat(matcher, ct.StringType("ok-name"))
+        self.assertIsInstance(errs, ct.ListType)
+        self.assertEqual(len(errs), 0)
+
+    def test_validateFormat_invalid(self):
+        matcher = named(ct.StringType("dns1123Label"))
+        errs = validateFormat(matcher, ct.StringType("Bad_Name"))
+        self.assertIsInstance(errs, ct.ListType)
+        self.assertGreater(len(errs), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_cel_ip_cidr_tests.py
+++ b/src/unittest/python/k8s_schema_cel_ip_cidr_tests.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+import celpy.celtypes as ct
+
+from kubernator.plugins.k8s_schema.cel.extensions.ip_lib import (
+    family,
+    ip,
+    isGlobalUnicast,
+    isIP,
+    isLinkLocalMulticast,
+    isLinkLocalUnicast,
+    isLoopback,
+    isUnspecified,
+)
+from kubernator.plugins.k8s_schema.cel.extensions.cidr_lib import (
+    cidr,
+    containsCIDR,
+    containsIP,
+    isCIDR,
+    masked,
+    prefixLength,
+)
+
+
+# ---- IP ----
+
+class IPTest(unittest.TestCase):
+    def test_ipv4(self):
+        result = ip(ct.StringType("10.0.0.1"))
+        self.assertEqual(str(result["address"]), "10.0.0.1")
+        self.assertEqual(result["family"], ct.IntType(4))
+
+    def test_ipv6(self):
+        result = ip(ct.StringType("::1"))
+        self.assertIn("_ip", result)
+        self.assertEqual(result["family"], ct.IntType(6))
+
+    def test_passthrough_already_wrapped(self):
+        wrapped = ip(ct.StringType("10.0.0.1"))
+        result = ip(wrapped)
+        self.assertEqual(str(result["address"]), "10.0.0.1")
+
+
+class IsIPTest(unittest.TestCase):
+    def test_valid_ipv4(self):
+        self.assertEqual(isIP(ct.StringType("192.168.1.1")), ct.BoolType(True))
+
+    def test_valid_ipv6(self):
+        self.assertEqual(isIP(ct.StringType("::1")), ct.BoolType(True))
+
+    def test_invalid(self):
+        self.assertEqual(isIP(ct.StringType("nope")), ct.BoolType(False))
+
+
+class FamilyTest(unittest.TestCase):
+    def test_ipv4(self):
+        self.assertEqual(family(ct.StringType("10.0.0.1")), ct.IntType(4))
+
+    def test_ipv6(self):
+        self.assertEqual(family(ct.StringType("::1")), ct.IntType(6))
+
+
+class IPPropertiesTest(unittest.TestCase):
+    def test_isLoopback_v4(self):
+        self.assertEqual(isLoopback(ct.StringType("127.0.0.1")),
+                         ct.BoolType(True))
+
+    def test_isLoopback_v6(self):
+        self.assertEqual(isLoopback(ct.StringType("::1")),
+                         ct.BoolType(True))
+
+    def test_isLoopback_false(self):
+        self.assertEqual(isLoopback(ct.StringType("10.0.0.1")),
+                         ct.BoolType(False))
+
+    def test_isUnspecified(self):
+        self.assertEqual(isUnspecified(ct.StringType("0.0.0.0")),
+                         ct.BoolType(True))
+        self.assertEqual(isUnspecified(ct.StringType("10.0.0.1")),
+                         ct.BoolType(False))
+
+    def test_isLinkLocalUnicast(self):
+        self.assertEqual(isLinkLocalUnicast(ct.StringType("169.254.1.1")),
+                         ct.BoolType(True))
+        self.assertEqual(isLinkLocalUnicast(ct.StringType("10.0.0.1")),
+                         ct.BoolType(False))
+
+    def test_isLinkLocalMulticast(self):
+        # Python's ipaddress.is_link_local covers unicast fe80::/10 only,
+        # so no multicast address satisfies both is_multicast AND is_link_local.
+        self.assertEqual(isLinkLocalMulticast(ct.StringType("ff02::1")),
+                         ct.BoolType(False))
+        self.assertEqual(isLinkLocalMulticast(ct.StringType("10.0.0.1")),
+                         ct.BoolType(False))
+
+    def test_isGlobalUnicast(self):
+        self.assertEqual(isGlobalUnicast(ct.StringType("8.8.8.8")),
+                         ct.BoolType(True))
+        self.assertEqual(isGlobalUnicast(ct.StringType("127.0.0.1")),
+                         ct.BoolType(False))
+
+
+# ---- CIDR ----
+
+class CIDRTest(unittest.TestCase):
+    def test_ipv4_cidr(self):
+        result = cidr(ct.StringType("10.0.0.0/8"))
+        self.assertIn("_cidr", result)
+        self.assertEqual(result["family"], ct.IntType(4))
+        self.assertEqual(result["prefixLength"], ct.IntType(8))
+
+    def test_ipv6_cidr(self):
+        result = cidr(ct.StringType("fd00::/64"))
+        self.assertEqual(result["family"], ct.IntType(6))
+        self.assertEqual(result["prefixLength"], ct.IntType(64))
+
+    def test_passthrough_already_wrapped(self):
+        wrapped = cidr(ct.StringType("10.0.0.0/8"))
+        result = cidr(wrapped)
+        self.assertEqual(result["family"], ct.IntType(4))
+
+
+class IsCIDRTest(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(isCIDR(ct.StringType("10.0.0.0/8")),
+                         ct.BoolType(True))
+
+    def test_invalid(self):
+        self.assertEqual(isCIDR(ct.StringType("nope")), ct.BoolType(False))
+
+
+class ContainsIPTest(unittest.TestCase):
+    def test_contained(self):
+        net = cidr(ct.StringType("10.0.0.0/8"))
+        addr = ip(ct.StringType("10.1.2.3"))
+        self.assertEqual(containsIP(net, addr), ct.BoolType(True))
+
+    def test_not_contained(self):
+        net = cidr(ct.StringType("10.0.0.0/8"))
+        addr = ip(ct.StringType("11.0.0.1"))
+        self.assertEqual(containsIP(net, addr), ct.BoolType(False))
+
+
+class ContainsCIDRTest(unittest.TestCase):
+    def test_supernet(self):
+        outer = cidr(ct.StringType("10.0.0.0/8"))
+        inner = cidr(ct.StringType("10.1.0.0/16"))
+        self.assertEqual(containsCIDR(outer, inner), ct.BoolType(True))
+
+    def test_not_supernet(self):
+        outer = cidr(ct.StringType("10.0.0.0/16"))
+        inner = cidr(ct.StringType("10.0.0.0/8"))
+        self.assertEqual(containsCIDR(outer, inner), ct.BoolType(False))
+
+
+class PrefixLengthTest(unittest.TestCase):
+    def test_from_string(self):
+        self.assertEqual(prefixLength(ct.StringType("10.0.0.0/24")),
+                         ct.IntType(24))
+
+
+class MaskedTest(unittest.TestCase):
+    def test_canonical_form(self):
+        result = masked(ct.StringType("10.1.2.3/8"))
+        self.assertEqual(str(result["cidr"]), "10.0.0.0/8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_cel_lists_tests.py
+++ b/src/unittest/python/k8s_schema_cel_lists_tests.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+import celpy.celtypes as ct
+
+from kubernator.plugins.k8s_schema.cel.extensions.lists import (
+    indexOf,
+    lastIndexOf,
+    max,
+    min,
+    sum,
+)
+
+
+class IndexOfTest(unittest.TestCase):
+    def test_found(self):
+        seq = ct.ListType([ct.StringType("a"), ct.StringType("b"),
+                           ct.StringType("c")])
+        self.assertEqual(indexOf(seq, ct.StringType("b")), ct.IntType(1))
+
+    def test_not_found(self):
+        seq = ct.ListType([ct.StringType("a"), ct.StringType("b")])
+        self.assertEqual(indexOf(seq, ct.StringType("z")), ct.IntType(-1))
+
+
+class LastIndexOfTest(unittest.TestCase):
+    def test_multiple_occurrences(self):
+        seq = ct.ListType([ct.StringType("a"), ct.StringType("b"),
+                           ct.StringType("a")])
+        self.assertEqual(lastIndexOf(seq, ct.StringType("a")), ct.IntType(2))
+
+    def test_not_found(self):
+        seq = ct.ListType([ct.StringType("a"), ct.StringType("b")])
+        self.assertEqual(lastIndexOf(seq, ct.StringType("z")), ct.IntType(-1))
+
+    def test_single_occurrence(self):
+        seq = ct.ListType([ct.StringType("x"), ct.StringType("y")])
+        self.assertEqual(lastIndexOf(seq, ct.StringType("x")), ct.IntType(0))
+
+
+class MinTest(unittest.TestCase):
+    def test_integers(self):
+        seq = ct.ListType([ct.IntType(3), ct.IntType(1), ct.IntType(2)])
+        self.assertEqual(min(seq), ct.IntType(1))
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            min(ct.ListType())
+
+
+class MaxTest(unittest.TestCase):
+    def test_integers(self):
+        seq = ct.ListType([ct.IntType(3), ct.IntType(1), ct.IntType(2)])
+        self.assertEqual(max(seq), ct.IntType(3))
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            max(ct.ListType())
+
+
+class SumTest(unittest.TestCase):
+    def test_integers(self):
+        seq = ct.ListType([ct.IntType(3), ct.IntType(1), ct.IntType(2)])
+        self.assertEqual(sum(seq), ct.IntType(6))
+
+    def test_empty(self):
+        self.assertEqual(sum(ct.ListType()), ct.IntType(0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_cel_quantity_tests.py
+++ b/src/unittest/python/k8s_schema_cel_quantity_tests.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from decimal import Decimal
+
+import celpy.celtypes as ct
+
+from kubernator.plugins.k8s_schema.cel.extensions.quantity import (
+    _Quantity,
+    _parse,
+    add,
+    asApproximateFloat,
+    asInteger,
+    compareTo,
+    isGreaterThan,
+    isInteger,
+    isLessThan,
+    isQuantity,
+    quantity,
+    sign,
+    sub,
+)
+
+
+class ParseTest(unittest.TestCase):
+    def test_plain_integer(self):
+        q = _parse("100")
+        self.assertEqual(q.value, Decimal("100"))
+
+    def test_decimal_with_fraction(self):
+        q = _parse("1.5")
+        self.assertEqual(q.value, Decimal("1.5"))
+
+    def test_si_suffix_milli(self):
+        q = _parse("500m")
+        self.assertEqual(q.value, Decimal("0.5"))
+
+    def test_si_suffix_kilo(self):
+        q = _parse("2k")
+        self.assertEqual(q.value, Decimal("2000"))
+
+    def test_binary_suffix_mi(self):
+        q = _parse("100Mi")
+        self.assertEqual(q.value, Decimal(100) * Decimal(2) ** 20)
+
+    def test_binary_suffix_gi(self):
+        q = _parse("2Gi")
+        self.assertEqual(q.value, Decimal(2) * Decimal(2) ** 30)
+
+    def test_exponent(self):
+        q = _parse("1e3")
+        self.assertEqual(q.value, Decimal("1000"))
+
+    def test_negative(self):
+        q = _parse("-500m")
+        self.assertEqual(q.value, Decimal("-0.5"))
+
+    def test_leading_dot(self):
+        q = _parse(".5")
+        self.assertEqual(q.value, Decimal("0.5"))
+
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            _parse("notaquantity")
+
+    def test_repr(self):
+        q = _Quantity(Decimal("100"), "Mi")
+        self.assertIn("100", repr(q))
+        self.assertIn("Mi", repr(q))
+
+
+class QuantityFunctionTest(unittest.TestCase):
+    def test_from_string(self):
+        q = quantity(ct.StringType("100Mi"))
+        self.assertIn("_quantity", q)
+
+    def test_passthrough_already_wrapped(self):
+        q1 = quantity(ct.StringType("100Mi"))
+        q2 = quantity(q1)
+        self.assertIs(q1, q2)
+
+
+class IsQuantityTest(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(isQuantity(ct.StringType("100Mi")), ct.BoolType(True))
+        self.assertEqual(isQuantity(ct.StringType("500m")), ct.BoolType(True))
+
+    def test_invalid(self):
+        self.assertEqual(isQuantity(ct.StringType("nope")), ct.BoolType(False))
+
+
+class ArithmeticTest(unittest.TestCase):
+    def _q(self, s):
+        return quantity(ct.StringType(s))
+
+    def test_add(self):
+        result = add(self._q("100"), self._q("200"))
+        self.assertEqual(Decimal(str(result["value"])), Decimal("300"))
+
+    def test_sub(self):
+        result = sub(self._q("300"), self._q("100"))
+        self.assertEqual(Decimal(str(result["value"])), Decimal("200"))
+
+    def test_isLessThan(self):
+        self.assertEqual(isLessThan(self._q("100"), self._q("200")),
+                         ct.BoolType(True))
+        self.assertEqual(isLessThan(self._q("200"), self._q("100")),
+                         ct.BoolType(False))
+
+    def test_isGreaterThan(self):
+        self.assertEqual(isGreaterThan(self._q("200"), self._q("100")),
+                         ct.BoolType(True))
+        self.assertEqual(isGreaterThan(self._q("100"), self._q("200")),
+                         ct.BoolType(False))
+
+    def test_compareTo(self):
+        self.assertEqual(compareTo(self._q("100"), self._q("200")),
+                         ct.IntType(-1))
+        self.assertEqual(compareTo(self._q("200"), self._q("100")),
+                         ct.IntType(1))
+        self.assertEqual(compareTo(self._q("100"), self._q("100")),
+                         ct.IntType(0))
+
+
+class ConversionTest(unittest.TestCase):
+    def _q(self, s):
+        return quantity(ct.StringType(s))
+
+    def test_asInteger(self):
+        self.assertEqual(asInteger(self._q("42")), ct.IntType(42))
+
+    def test_asInteger_overflow(self):
+        huge = quantity(ct.StringType("1E30"))
+        with self.assertRaises(OverflowError):
+            asInteger(huge)
+
+    def test_asApproximateFloat(self):
+        result = asApproximateFloat(self._q("1.5"))
+        self.assertEqual(result, ct.DoubleType(1.5))
+
+    def test_isInteger_true(self):
+        self.assertEqual(isInteger(self._q("42")), ct.BoolType(True))
+
+    def test_isInteger_false(self):
+        self.assertEqual(isInteger(self._q("1.5")), ct.BoolType(False))
+
+
+class SignTest(unittest.TestCase):
+    def _q(self, s):
+        return quantity(ct.StringType(s))
+
+    def test_positive(self):
+        self.assertEqual(sign(self._q("100")), ct.IntType(1))
+
+    def test_negative(self):
+        self.assertEqual(sign(self._q("-100")), ct.IntType(-1))
+
+    def test_zero(self):
+        self.assertEqual(sign(self._q("0")), ct.IntType(0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_cel_regex_optional_tests.py
+++ b/src/unittest/python/k8s_schema_cel_regex_optional_tests.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+import celpy.celtypes as ct
+
+from kubernator.plugins.k8s_schema.cel.extensions.regex_lib import (
+    find,
+    findAll,
+)
+from kubernator.plugins.k8s_schema.cel.extensions.optional_lib import (
+    NONE,
+    OPTIONAL_SENTINEL,
+    hasValue,
+    none,
+    of,
+    orValue,
+    value,
+    wrap,
+)
+
+
+# ---- regex ----
+
+class FindTest(unittest.TestCase):
+    def test_match(self):
+        result = find(ct.StringType("foo-123-bar"), ct.StringType("[0-9]+"))
+        self.assertEqual(result, ct.StringType("123"))
+
+    def test_no_match(self):
+        result = find(ct.StringType("foo"), ct.StringType("[0-9]+"))
+        self.assertEqual(result, ct.StringType(""))
+
+
+class FindAllTest(unittest.TestCase):
+    def test_multiple_matches(self):
+        result = findAll(ct.StringType("a1 b2 c3"), ct.StringType("[0-9]"))
+        self.assertEqual(len(result), 3)
+
+    def test_with_limit(self):
+        result = findAll(ct.StringType("a1 b2 c3"), ct.StringType("[0-9]"),
+                         ct.IntType(2))
+        self.assertEqual(len(result), 2)
+
+    def test_grouped_pattern(self):
+        result = findAll(ct.StringType("a1 b2"), ct.StringType("([a-z])([0-9])"))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], ct.StringType("a"))
+
+
+# ---- optional ----
+
+class OptionalWrapTest(unittest.TestCase):
+    def test_wrap_value(self):
+        w = wrap(ct.IntType(42))
+        self.assertEqual(w["_hasValue"], ct.BoolType(True))
+        self.assertEqual(w["_value"], ct.IntType(42))
+
+    def test_none_constant(self):
+        self.assertEqual(NONE["_hasValue"], ct.BoolType(False))
+
+
+class OptionalCELFunctionsTest(unittest.TestCase):
+    def test_of(self):
+        result = of(OPTIONAL_SENTINEL, ct.IntType(5))
+        self.assertEqual(result["_hasValue"], ct.BoolType(True))
+        self.assertEqual(result["_value"], ct.IntType(5))
+
+    def test_none_function(self):
+        result = none(OPTIONAL_SENTINEL)
+        self.assertIs(result, NONE)
+
+    def test_hasValue_present(self):
+        w = wrap(ct.IntType(1))
+        self.assertEqual(hasValue(w), ct.BoolType(True))
+
+    def test_hasValue_absent(self):
+        self.assertEqual(hasValue(NONE), ct.BoolType(False))
+
+    def test_value_present(self):
+        w = wrap(ct.IntType(42))
+        self.assertEqual(value(w), ct.IntType(42))
+
+    def test_value_absent_raises(self):
+        with self.assertRaises(ValueError):
+            value(NONE)
+
+    def test_orValue_present(self):
+        w = wrap(ct.IntType(3))
+        self.assertEqual(orValue(w, ct.IntType(7)), ct.IntType(3))
+
+    def test_orValue_absent(self):
+        self.assertEqual(orValue(NONE, ct.IntType(7)), ct.IntType(7))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_cel_tests.py
+++ b/src/unittest/python/k8s_schema_cel_tests.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from unittest.mock import patch
+
+from kubernator.plugins.k8s_schema.cel import CELEvaluator
+from kubernator.plugins.k8s_schema.cel.rules import (ARRAY_ITEM,
+                                                     collect_rules,
+                                                     format_path,
+                                                     resolve_path)
+
+
+# ------------------------------------------------------------------ walker
+
+
+class RuleWalkerTest(unittest.TestCase):
+    def test_finds_nested_rules(self):
+        schema = {
+            "type": "object",
+            "x-kubernetes-validations": [{"rule": "true", "message": "root"}],
+            "properties": {
+                "a": {
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {"rule": "self.x > 0"},
+                    ],
+                    "properties": {"x": {"type": "integer"}},
+                },
+                "b": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                            {"rule": "self.name.size() > 0"},
+                        ],
+                    },
+                },
+            },
+        }
+        paths = [(p, r["rule"]) for p, r in collect_rules(schema)]
+        self.assertIn(([], "true"), paths)
+        self.assertIn((["a"], "self.x > 0"), paths)
+        self.assertIn((["b", ARRAY_ITEM], "self.name.size() > 0"), paths)
+
+    def test_finds_rules_in_oneOf_branches(self):
+        schema = {"oneOf": [
+            {"type": "object",
+             "x-kubernetes-validations": [{"rule": "branch1"}]},
+            {"type": "object",
+             "x-kubernetes-validations": [{"rule": "branch2"}]},
+        ]}
+        rules = [r["rule"] for _, r in collect_rules(schema)]
+        self.assertEqual(sorted(rules), ["branch1", "branch2"])
+
+
+class ResolvePathTest(unittest.TestCase):
+    def test_resolve_scalar_path(self):
+        self.assertEqual(list(resolve_path({"a": {"b": 3}}, ["a", "b"])), [3])
+
+    def test_resolve_array_items(self):
+        self.assertEqual(
+            sorted(resolve_path({"a": [1, 2, 3]}, ["a", ARRAY_ITEM])),
+            [1, 2, 3])
+
+    def test_format_path_dotted_and_arrays(self):
+        self.assertEqual(format_path(["a", ARRAY_ITEM, "b"]),
+                         "$.a[*].b")
+
+
+# ------------------------------------------------------------------ evaluator
+
+
+class CELEvaluatorTest(unittest.TestCase):
+    def setUp(self):
+        self.ev = CELEvaluator()
+
+    def _eval(self, schema, manifest, **kw):
+        return list(self.ev.iter_rule_errors(manifest, schema, **kw))
+
+    def test_simple_pass(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.replicas <= 10", "message": "too many"}]}
+        self.assertEqual(self._eval(schema, {"replicas": 3}), [])
+
+    def test_simple_fail(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.replicas <= 10", "message": "too many"}]}
+        errs = self._eval(schema, {"replicas": 12})
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(errs[0].message, "too many")
+
+    def test_transition_rule_skipped_without_old(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.kind == oldSelf.kind", "message": "immutable"}]}
+        self.assertEqual(self._eval(schema, {"kind": "A"}), [])
+
+    def test_transition_rule_fires_with_old(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.kind == oldSelf.kind", "message": "immutable"}]}
+        errs = self._eval(schema, {"kind": "A"},
+                          old_manifest={"kind": "B"})
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(errs[0].message, "immutable")
+
+    def test_transition_rule_passes_when_unchanged(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.kind == oldSelf.kind", "message": "immutable"}]}
+        self.assertEqual(
+            self._eval(schema, {"kind": "A"}, old_manifest={"kind": "A"}),
+            [])
+
+    def test_message_expression(self):
+        schema = {"x-kubernetes-validations": [{
+            "rule": "self.n < 5",
+            "messageExpression": "'n=' + string(self.n) + ' too big'",
+        }]}
+        errs = self._eval(schema, {"n": 10})
+        self.assertEqual(errs[0].message, "n=10 too big")
+
+    def test_malformed_rule_does_not_abort_others(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "@@syntax error"},
+            {"rule": "self.n < 5", "message": "too big"},
+        ]}
+        errs = self._eval(schema, {"n": 10})
+        # We should see both a compile-failure error and the real failure.
+        self.assertGreaterEqual(len(errs), 2)
+
+    def test_compile_cache_is_shared(self):
+        # First eval triggers a compile; second should reuse it.
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.x > 0"}]}
+        # Spy on celpy compile via patch on env
+        with patch.object(self.ev._env, "compile",
+                          wraps=self.ev._env.compile) as spy:
+            self._eval(schema, {"x": 1})
+            self._eval(schema, {"x": 5})
+            self.assertEqual(spy.call_count, 1)
+
+    def test_array_item_binding(self):
+        schema = {"properties": {"items": {
+            "type": "array",
+            "items": {"type": "object",
+                      "x-kubernetes-validations": [
+                          {"rule": "self.n >= 0", "message": "negative"}]}}}}
+        errs = self._eval(schema, {"items": [{"n": 1}, {"n": -1}]})
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(errs[0].message, "negative")
+
+
+# ------------------------------------------------------------------ ext libs
+
+
+class ExtensionLibrariesTest(unittest.TestCase):
+    """One representative positive-and-negative check per library so we
+    exercise the registered function surface and catch regressions."""
+
+    def setUp(self):
+        self.ev = CELEvaluator()
+
+    def _eval(self, expr, self_value):
+        schema = {"x-kubernetes-validations": [
+            {"rule": expr, "message": "fail"}]}
+        return list(self.ev.iter_rule_errors(self_value, schema))
+
+    # ----- lists
+    def test_list_indexOf(self):
+        self.assertEqual(self._eval("['a','b','c'].indexOf('b') == 1", {}), [])
+        self.assertTrue(self._eval("['a','b','c'].indexOf('z') != -1", {}))
+
+    def test_list_min_max_sum(self):
+        self.assertEqual(self._eval("[3,1,2].min() == 1", {}), [])
+        self.assertEqual(self._eval("[3,1,2].max() == 3", {}), [])
+        self.assertEqual(self._eval("[3,1,2].sum() == 6", {}), [])
+
+    # ----- regex
+    def test_regex_find(self):
+        self.assertEqual(
+            self._eval("'foo-123'.find('[0-9]+') == '123'", {}), [])
+
+    def test_regex_findAll(self):
+        self.assertEqual(
+            self._eval("'a1 b2 c3'.findAll('[0-9]').size() == 3", {}), [])
+
+    # ----- quantity
+    def test_quantity_isQuantity(self):
+        self.assertEqual(self._eval("isQuantity('100Mi')", {}), [])
+        self.assertTrue(self._eval("isQuantity('nope')", {}))
+
+    def test_quantity_compare(self):
+        self.assertEqual(
+            self._eval("quantity('2Gi').isGreaterThan(quantity('500Mi'))", {}),
+            [])
+
+    # ----- IP
+    def test_ip_isIP(self):
+        self.assertEqual(self._eval("isIP('10.0.0.1')", {}), [])
+        self.assertTrue(self._eval("isIP('nope')", {}))
+
+    def test_ip_isLoopback(self):
+        self.assertEqual(self._eval("ip('127.0.0.1').isLoopback()", {}), [])
+
+    # ----- CIDR
+    def test_cidr_containsIP(self):
+        self.assertEqual(
+            self._eval("cidr('10.0.0.0/8').containsIP(ip('10.1.2.3'))", {}),
+            [])
+        self.assertTrue(
+            self._eval("cidr('10.0.0.0/8').containsIP(ip('11.0.0.1'))", {}))
+
+    # ----- format
+    def test_format_named_dns1123Label(self):
+        # Valid empty error list means format OK.
+        self.assertEqual(
+            self._eval("namedFormat('dns1123Label').validateFormat('ok-name')"
+                       ".size() == 0", {}),
+            [])
+        # Invalid value yields non-empty error list.
+        self.assertEqual(
+            self._eval("namedFormat('dns1123Label').validateFormat('Bad_Name')"
+                       ".size() > 0", {}),
+            [])
+
+    # ----- optional
+    def test_optional_of_has_value(self):
+        self.assertEqual(self._eval("optional.of(5).hasValue()", {}), [])
+
+    def test_optional_none_has_no_value(self):
+        self.assertEqual(self._eval("!optional.none().hasValue()", {}), [])
+
+    def test_optional_value_returns_underlying(self):
+        self.assertEqual(self._eval("optional.of(42).value() == 42", {}), [])
+
+    def test_optional_or_value_defaults_on_none(self):
+        self.assertEqual(self._eval("optional.none().orValue(7) == 7", {}), [])
+        self.assertEqual(self._eval("optional.of(3).orValue(7) == 3", {}), [])
+
+
+class CELEvalRuleEdgeCasesTest(unittest.TestCase):
+    """Tests for edge-case branches in _eval_rule and _evaluate_one."""
+
+    def setUp(self):
+        self.ev = CELEvaluator()
+
+    def _eval(self, schema, manifest, **kw):
+        return list(self.ev.iter_rule_errors(manifest, schema, **kw))
+
+    def test_empty_rule_expression_skipped(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "", "message": "should not fire"}]}
+        self.assertEqual(self._eval(schema, {"x": 1}), [])
+
+    def test_non_bool_result_yields_error(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "42", "message": "should not fire"}]}
+        errs = self._eval(schema, {})
+        self.assertEqual(len(errs), 1)
+        self.assertIn("non-bool", errs[0].message)
+
+    def test_field_path_appended_to_error(self):
+        schema = {"x-kubernetes-validations": [{
+            "rule": "self.n < 5",
+            "message": "too big",
+            "fieldPath": ".spec.n",
+        }]}
+        errs = self._eval(schema, {"n": 10})
+        self.assertEqual(len(errs), 1)
+
+    def test_default_message_when_no_message_or_expression(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "self.n < 5"}]}
+        errs = self._eval(schema, {"n": 10})
+        self.assertEqual(len(errs), 1)
+        self.assertIn("failed", errs[0].message)
+
+    def test_cel_eval_error_yields_error(self):
+        schema = {"x-kubernetes-validations": [{
+            "rule": "self.nonexistent.deeply.nested > 0",
+            "message": "should not matter"}]}
+        errs = self._eval(schema, {})
+        self.assertGreaterEqual(len(errs), 1)
+
+    def test_resolve_path_on_additionalProperties_dict(self):
+        schema = {"properties": {"labels": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "x-kubernetes-validations": [{
+                    "rule": "self.v != 'bad'", "message": "bad value"}]}}}}
+        errs = self._eval(schema, {"labels": {
+            "a": {"v": "ok"},
+            "b": {"v": "bad"}}})
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(errs[0].message, "bad value")
+
+
+class RulesWalkerEdgeCasesTest(unittest.TestCase):
+    def test_single_rule_dict_shorthand(self):
+        from kubernator.plugins.k8s_schema.cel.rules import collect_rules
+        schema = {"x-kubernetes-validations": {"rule": "true"}}
+        rules = list(collect_rules(schema))
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0][1]["rule"], "true")
+
+    def test_additionalProperties_walk(self):
+        from kubernator.plugins.k8s_schema.cel.rules import collect_rules, ARRAY_ITEM
+        schema = {"additionalProperties": {
+            "type": "object",
+            "x-kubernetes-validations": [{"rule": "self.x > 0"}]}}
+        rules = list(collect_rules(schema))
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0][0], [ARRAY_ITEM])
+
+    def test_resolve_path_map_values(self):
+        values = list(resolve_path({"m": {"a": 1, "b": 2}},
+                                   ["m", ARRAY_ITEM]))
+        self.assertEqual(sorted(values), [1, 2])
+
+
+class OptionalSelfSemanticsTest(unittest.TestCase):
+    """Rules declaring optionalSelf/optionalOldSelf receive wrapped
+    bindings so ``self.hasValue()`` / ``oldSelf.hasValue()`` work even
+    when the underlying field is absent."""
+
+    def setUp(self):
+        self.ev = CELEvaluator()
+
+    def _eval(self, schema, manifest, **kw):
+        return list(self.ev.iter_rule_errors(manifest, schema, **kw))
+
+    def test_optional_self_absent_binds_none(self):
+        schema = {"properties": {
+            "spec": {"type": "object",
+                     "x-kubernetes-validations": [
+                         {"rule": "!self.hasValue() || self.value().n > 0",
+                          "optionalSelf": True,
+                          "message": "n must be > 0 when present"}]}}}
+        # spec is absent → optionalSelf binds self=none → rule holds
+        self.assertEqual(self._eval(schema, {}), [])
+        # spec present with n>0 → passes
+        self.assertEqual(self._eval(schema, {"spec": {"n": 1}}), [])
+        # spec present with n=0 → fails
+        errs = self._eval(schema, {"spec": {"n": 0}})
+        self.assertEqual(len(errs), 1)
+
+    def test_optional_old_self_absent_binds_none(self):
+        schema = {"x-kubernetes-validations": [
+            {"rule": "!oldSelf.hasValue() || self.kind == oldSelf.value().kind",
+             "optionalOldSelf": True,
+             "message": "kind is immutable"}]}
+        # first apply (no old): rule must short-circuit to true
+        self.assertEqual(self._eval(schema, {"kind": "A"}), [])
+        # subsequent apply with matching old: passes
+        self.assertEqual(
+            self._eval(schema, {"kind": "A"}, old_manifest={"kind": "A"}),
+            [])
+        # subsequent apply changing kind: fails
+        errs = self._eval(schema, {"kind": "B"}, old_manifest={"kind": "A"})
+        self.assertEqual(len(errs), 1)

--- a/src/unittest/python/k8s_schema_factory_tests.py
+++ b/src/unittest/python/k8s_schema_factory_tests.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from unittest.mock import patch
+
+from kubernator.api import PropertyDict
+from kubernator.plugins.k8s_schema import make_validator
+from kubernator.plugins.k8s_schema.sources import ClusterSource, GitHubSource
+from kubernator.plugins.k8s_schema.v2 import SwaggerV2Validator
+
+
+SWAGGER_FIXTURE = {
+    "paths": {},
+    "definitions": {
+        "io.k8s.api.core.v1.ConfigMap": {
+            "type": "object",
+            "x-kubernetes-group-version-kind": [
+                {"group": "", "version": "v1", "kind": "ConfigMap"}],
+            "properties": {},
+        },
+    },
+}
+
+
+def _ctx(minor="30", *, openapi_version="auto", openapi_source="auto",
+         with_client=True):
+    ctx = PropertyDict()
+    ctx.k8s = dict(
+        server_version=["1", str(minor), "0"],
+        server_git_version=f"v1.{minor}.0",
+        client=object() if with_client else None,
+    )
+    ctx.globals = PropertyDict()
+    ctx.globals.k8s = dict(
+        openapi_version=openapi_version,
+        openapi_source=openapi_source,
+    )
+    return ctx
+
+
+class _FakeSource:
+    def __init__(self, name, index=None, raise_on_fetch=False):
+        self.name = name
+        self.index = index or {"api/v1": "/openapi/v3/api/v1?h=x"}
+        self.raise_on_fetch = raise_on_fetch
+
+    def fetch_index(self):
+        if self.raise_on_fetch:
+            raise RuntimeError(f"{self.name} down")
+        return self.index
+
+    def fetch_document(self, *args, **kwargs):  # pragma: no cover
+        return {"components": {"schemas": {}}, "paths": {}}
+
+
+class FactoryTest(unittest.TestCase):
+    # ---------- v3 path
+    def test_auto_on_modern_server_picks_v3(self):
+        ctx = _ctx(minor=30)
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls:
+            instance = v3cls.return_value
+            instance.load.return_value = None
+            result = make_validator(ctx)
+            self.assertIs(result, instance)
+            instance.load.assert_called_once()
+
+    def test_auto_on_modern_server_v3_failure_falls_back_to_v2(self):
+        ctx = _ctx(minor=30)
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls, \
+             patch("kubernator.plugins.k8s_schema.v2.load_remote_file",
+                   return_value=SWAGGER_FIXTURE):
+            v3cls.return_value.load.side_effect = RuntimeError("both sources down")
+            result = make_validator(ctx)
+            self.assertIsInstance(result, SwaggerV2Validator)
+
+    def test_auto_on_legacy_server_picks_v2(self):
+        ctx = _ctx(minor=26)
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls, \
+             patch("kubernator.plugins.k8s_schema.v2.load_remote_file",
+                   return_value=SWAGGER_FIXTURE):
+            result = make_validator(ctx)
+            self.assertIsInstance(result, SwaggerV2Validator)
+            v3cls.assert_not_called()
+
+    def test_forced_v3_attempts_regardless_of_gate(self):
+        ctx = _ctx(minor=26, openapi_version="v3")
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls:
+            v3cls.return_value.load.return_value = None
+            make_validator(ctx)
+            v3cls.assert_called_once()
+
+    def test_forced_v3_cluster_failure_raises(self):
+        ctx = _ctx(minor=30, openapi_version="v3", openapi_source="cluster")
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls:
+            v3cls.return_value.load.side_effect = RuntimeError("nope")
+            with self.assertRaises(RuntimeError):
+                make_validator(ctx)
+
+    def test_forced_v3_github_skips_cluster(self):
+        ctx = _ctx(minor=30, openapi_version="v3", openapi_source="github")
+        captured = {}
+
+        class FakeV3:
+            def __init__(self, context, sources):
+                captured["sources"] = sources
+
+            def load(self):
+                return None
+
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator", FakeV3):
+            make_validator(ctx)
+        self.assertEqual(len(captured["sources"]), 1)
+        self.assertIsInstance(captured["sources"][0], GitHubSource)
+
+    def test_forced_v2_always_returns_v2(self):
+        ctx = _ctx(minor=30, openapi_version="v2")
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls, \
+             patch("kubernator.plugins.k8s_schema.v2.load_remote_file",
+                   return_value=SWAGGER_FIXTURE):
+            result = make_validator(ctx)
+            self.assertIsInstance(result, SwaggerV2Validator)
+            v3cls.assert_not_called()
+
+    def test_explicit_kwarg_overrides_context(self):
+        ctx = _ctx(minor=30, openapi_version="v2")
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator") as v3cls:
+            v3cls.return_value.load.return_value = None
+            make_validator(ctx, openapi_version="v3")
+            v3cls.assert_called_once()
+
+    def test_source_auto_puts_cluster_first(self):
+        ctx = _ctx(minor=30)
+        captured = {}
+
+        class FakeV3:
+            def __init__(self, context, sources):
+                captured["sources"] = sources
+
+            def load(self):
+                return None
+
+        with patch("kubernator.plugins.k8s_schema.OpenAPIV3Validator", FakeV3):
+            make_validator(ctx)
+        self.assertEqual(len(captured["sources"]), 2)
+        self.assertIsInstance(captured["sources"][0], ClusterSource)
+        self.assertIsInstance(captured["sources"][1], GitHubSource)
+
+    def test_invalid_openapi_version_raises(self):
+        ctx = _ctx(minor=30, openapi_version="v4")
+        with self.assertRaises(ValueError):
+            make_validator(ctx)
+
+    def test_invalid_openapi_source_raises(self):
+        ctx = _ctx(minor=30, openapi_source="s3")
+        with self.assertRaises(ValueError):
+            make_validator(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_sources_tests.py
+++ b/src/unittest/python/k8s_schema_sources_tests.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from kubernator.plugins.k8s_schema.sources import (
+    ClusterSource,
+    GitHubSource,
+    _filename_to_gv_path,
+    _gv_path_to_filename,
+)
+
+
+class FilenameConversionTest(unittest.TestCase):
+    def test_core_round_trip(self):
+        path = "api/v1"
+        filename = _gv_path_to_filename(path)
+        self.assertEqual(filename, "api__v1_openapi.json")
+        self.assertEqual(_filename_to_gv_path(filename), path)
+
+    def test_grouped_round_trip(self):
+        path = "apis/apps/v1"
+        filename = _gv_path_to_filename(path)
+        self.assertEqual(filename, "apis__apps__v1_openapi.json")
+        self.assertEqual(_filename_to_gv_path(filename), path)
+
+    def test_filename_to_gv_path_non_conforming(self):
+        self.assertIsNone(_filename_to_gv_path("README.md"))
+        self.assertIsNone(_filename_to_gv_path("random.json"))
+
+
+class ClusterSourceTest(unittest.TestCase):
+    def _make(self):
+        client = MagicMock()
+        return ClusterSource(client), client
+
+    def test_fetch_index(self):
+        src, client = self._make()
+        resp = MagicMock()
+        resp.data = json.dumps({"paths": {
+            "api/v1": {"serverRelativeURL": "/openapi/v3/api/v1?hash=aaa"},
+            "apis/apps/v1": {"serverRelativeURL": "/openapi/v3/apis/apps/v1?hash=bbb"},
+        }}).encode()
+        client.call_api.return_value = resp
+        index = src.fetch_index()
+        self.assertEqual(index["api/v1"], "/openapi/v3/api/v1?hash=aaa")
+        self.assertEqual(index["apis/apps/v1"], "/openapi/v3/apis/apps/v1?hash=bbb")
+        client.call_api.assert_called_once()
+
+    def test_fetch_document(self):
+        src, client = self._make()
+        doc = {"components": {"schemas": {}}, "paths": {}}
+        resp = MagicMock()
+        resp.data = json.dumps(doc).encode()
+        client.call_api.return_value = resp
+        result = src.fetch_document("api/v1", "/openapi/v3/api/v1?hash=aaa")
+        self.assertEqual(result, doc)
+        call_kwargs = client.call_api.call_args
+        self.assertIn("query_params", call_kwargs.kwargs)
+
+    def test_fetch_document_preserves_query_params(self):
+        src, client = self._make()
+        resp = MagicMock()
+        resp.data = b'{"components":{}}'
+        client.call_api.return_value = resp
+        src.fetch_document("api/v1", "/openapi/v3/api/v1?hash=aaa&foo=bar")
+        call_kwargs = client.call_api.call_args
+        query = dict(call_kwargs.kwargs["query_params"])
+        self.assertIn("hash", query)
+        self.assertIn("foo", query)
+
+
+class GitHubSourceTest(unittest.TestCase):
+    def test_fetch_index(self):
+        src = GitHubSource("v1.30.2")
+        listing = [
+            {"name": "api__v1_openapi.json"},
+            {"name": "apis__apps__v1_openapi.json"},
+            {"name": "README.md"},
+            {"name": ""},
+        ]
+        with patch("kubernator.plugins.k8s_schema.sources.load_remote_file",
+                   return_value=listing):
+            index = src.fetch_index()
+        self.assertIn("api/v1", index)
+        self.assertIn("apis/apps/v1", index)
+        self.assertEqual(len(index), 2)
+
+    def test_fetch_index_single_dict(self):
+        src = GitHubSource("v1.30.2")
+        listing = {"name": "api__v1_openapi.json"}
+        with patch("kubernator.plugins.k8s_schema.sources.load_remote_file",
+                   return_value=listing):
+            index = src.fetch_index()
+        self.assertEqual(index, {"api/v1": "api__v1_openapi.json"})
+
+    def test_fetch_document(self):
+        src = GitHubSource("v1.30.2")
+        doc = {"components": {"schemas": {}}}
+        with patch("kubernator.plugins.k8s_schema.sources.load_remote_file",
+                   return_value=doc):
+            result = src.fetch_document("api/v1", "api__v1_openapi.json")
+        self.assertEqual(result, doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/unittest/python/k8s_schema_v2_tests.py
+++ b/src/unittest/python/k8s_schema_v2_tests.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from kubernator.api import PropertyDict
+from kubernator.plugins.k8s_api import K8SResourceDefKey
+from kubernator.plugins.k8s_schema.v2 import SwaggerV2Validator
+
+
+SWAGGER_FIXTURE = {
+    "paths": {
+        "/api/v1/namespaces/{namespace}/configmaps": {
+            "get": {
+                "x-kubernetes-action": "list",
+                "x-kubernetes-group-version-kind": {
+                    "group": "", "version": "v1", "kind": "ConfigMap"},
+            },
+            "post": {
+                "x-kubernetes-action": "post",
+                "x-kubernetes-group-version-kind": {
+                    "group": "", "version": "v1", "kind": "ConfigMap"},
+            },
+        },
+        "/apis/apps/v1/namespaces/{namespace}/deployments": {
+            "get": {
+                "x-kubernetes-action": "list",
+                "x-kubernetes-group-version-kind": {
+                    "group": "apps", "version": "v1", "kind": "Deployment"},
+            },
+        },
+    },
+    "definitions": {
+        "io.k8s.api.core.v1.ConfigMap": {
+            "type": "object",
+            "x-kubernetes-group-version-kind": [
+                {"group": "", "version": "v1", "kind": "ConfigMap"}],
+            "required": ["apiVersion", "kind"],
+            "properties": {
+                "apiVersion": {"type": "string"},
+                "kind": {"type": "string"},
+                "metadata": {"type": "object", "properties": {
+                    "name": {"type": "string"}, "namespace": {"type": "string"}},
+                    "required": ["name"]},
+                "data": {"type": "object",
+                         "additionalProperties": {"type": "string"}},
+            },
+        },
+        "io.k8s.api.apps.v1.Deployment": {
+            "type": "object",
+            "x-kubernetes-group-version-kind": [
+                {"group": "apps", "version": "v1", "kind": "Deployment"}],
+            "required": ["apiVersion", "kind"],
+            "properties": {
+                "apiVersion": {"type": "string"},
+                "kind": {"type": "string"},
+                "metadata": {"type": "object", "properties": {
+                    "name": {"type": "string"}}, "required": ["name"]},
+                "spec": {"type": "object", "properties": {
+                    "replicas": {"type": "integer"}}},
+            },
+        },
+    },
+}
+
+
+def _make_validator():
+    ctx = PropertyDict()
+    ctx.k8s = dict(server_git_version="v1.28.3")
+    v = SwaggerV2Validator(ctx)
+    with patch("kubernator.plugins.k8s_schema.v2.load_remote_file",
+               return_value=SWAGGER_FIXTURE):
+        v.load()
+    return v
+
+
+class SwaggerV2ValidatorTest(unittest.TestCase):
+    def test_load_populates_definitions_for_both_gvks(self):
+        v = _make_validator()
+        self.assertIn(K8SResourceDefKey("", "v1", "ConfigMap"),
+                      v.resource_definitions)
+        self.assertIn(K8SResourceDefKey("apps", "v1", "Deployment"),
+                      v.resource_definitions)
+
+    def test_api_versions_contains_core_and_apps(self):
+        v = _make_validator()
+        api_versions = list(v.api_versions())
+        self.assertIn("v1", api_versions)
+        self.assertIn("apps/v1", api_versions)
+
+    def test_iter_errors_passes_valid_manifest(self):
+        v = _make_validator()
+        rdef = v.resource_definitions[K8SResourceDefKey("", "v1", "ConfigMap")]
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                    "metadata": {"name": "cm"},
+                    "data": {"a": "1", "b": "2"}}
+        self.assertEqual(list(v.iter_errors(manifest, rdef)), [])
+
+    def test_iter_errors_rejects_wrong_type(self):
+        v = _make_validator()
+        rdef = v.resource_definitions[K8SResourceDefKey("apps", "v1", "Deployment")]
+        manifest = {"apiVersion": "apps/v1", "kind": "Deployment",
+                    "metadata": {"name": "d"},
+                    "spec": {"replicas": "three"}}  # should be integer
+        errors = list(v.iter_errors(manifest, rdef))
+        self.assertTrue(errors, "expected errors for non-integer replicas")
+
+    def test_iter_errors_accepts_old_manifest_kwarg(self):
+        v = _make_validator()
+        rdef = v.resource_definitions[K8SResourceDefKey("", "v1", "ConfigMap")]
+        manifest = {"apiVersion": "v1", "kind": "ConfigMap",
+                    "metadata": {"name": "cm"},
+                    "data": {"a": "1"}}
+        # should not raise; v2 ignores old_manifest
+        self.assertEqual(
+            list(v.iter_errors(manifest, rdef, old_manifest=manifest)), [])
+
+
+class BaseFormatCheckerTest(unittest.TestCase):
+    """Direct tests for k8s_format_checker format functions."""
+
+    def test_int32_valid(self):
+        from kubernator.plugins.k8s_schema.base import check_int32
+        self.assertTrue(check_int32(100))
+
+    def test_int32_none(self):
+        from kubernator.plugins.k8s_schema.base import check_int32
+        self.assertFalse(check_int32(None))
+
+    def test_int64_valid(self):
+        from kubernator.plugins.k8s_schema.base import check_int64
+        self.assertTrue(check_int64(2**40))
+
+    def test_float_valid(self):
+        from kubernator.plugins.k8s_schema.base import check_float
+        self.assertTrue(check_float(1.5))
+
+    def test_double_valid(self):
+        from kubernator.plugins.k8s_schema.base import check_double
+        self.assertTrue(check_double(1.5e100))
+
+    def test_byte_valid(self):
+        from kubernator.plugins.k8s_schema.base import check_byte
+        self.assertTrue(check_byte("SGVsbG8="))
+
+    def test_byte_invalid(self):
+        from kubernator.plugins.k8s_schema.base import check_byte
+        with self.assertRaises(ValueError):
+            check_byte("!!!invalid!!!")
+
+    def test_int_or_string_int(self):
+        from kubernator.plugins.k8s_schema.base import check_int_or_string
+        self.assertTrue(check_int_or_string(42))
+
+    def test_int_or_string_string(self):
+        from kubernator.plugins.k8s_schema.base import check_int_or_string
+        self.assertTrue(check_int_or_string("hello"))
+
+    def test_is_integer_rejects_bool(self):
+        from kubernator.plugins.k8s_schema.base import is_integer
+        self.assertFalse(is_integer(True))
+        self.assertTrue(is_integer(42))
+
+
+class ExtractGVKKeysTest(unittest.TestCase):
+    def test_single_dict(self):
+        from kubernator.plugins.k8s_schema.base import extract_gvk_keys
+        obj = {"x-kubernetes-group-version-kind":
+               {"group": "", "version": "v1", "kind": "ConfigMap"}}
+        keys = list(extract_gvk_keys(obj))
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0], K8SResourceDefKey("", "v1", "ConfigMap"))
+
+    def test_list_of_dicts(self):
+        from kubernator.plugins.k8s_schema.base import extract_gvk_keys
+        obj = {"x-kubernetes-group-version-kind": [
+            {"group": "", "version": "v1", "kind": "ConfigMap"},
+            {"group": "apps", "version": "v1", "kind": "Deployment"},
+        ]}
+        keys = list(extract_gvk_keys(obj))
+        self.assertEqual(len(keys), 2)
+
+    def test_missing_field(self):
+        from kubernator.plugins.k8s_schema.base import extract_gvk_keys
+        self.assertEqual(list(extract_gvk_keys({})), [])
+
+
+class IterManifestErrorsTest(unittest.TestCase):
+    def test_minimal_schema_rejects_missing_kind(self):
+        v = _make_validator()
+        errs = list(v.iter_manifest_errors({"apiVersion": "v1"}))
+        self.assertTrue(errs)
+
+    def test_unknown_gvk_yields_error(self):
+        v = _make_validator()
+        errs = list(v.iter_manifest_errors(
+            {"apiVersion": "v1", "kind": "NonExistent",
+             "metadata": {"name": "x"}}))
+        self.assertEqual(len(errs), 1)
+        self.assertIn("not a defined", str(errs[0].message))
+
+    def test_valid_manifest_passes(self):
+        v = _make_validator()
+        errs = list(v.iter_manifest_errors(
+            {"apiVersion": "v1", "kind": "ConfigMap",
+             "metadata": {"name": "cm"},
+             "data": {"a": "1", "b": "2"}}))
+        self.assertEqual(errs, [])
+
+
+class MixinDelegationTest(unittest.TestCase):
+    def test_resource_definitions_property_delegates_to_validator(self):
+        from kubernator.plugins.k8s_api import K8SResourcePluginMixin
+        mixin = K8SResourcePluginMixin()
+        mixin.validator = MagicMock()
+        fake = {"k": "v"}
+        mixin.validator.resource_definitions = fake
+        self.assertIs(mixin.resource_definitions, fake)
+
+    def test_get_api_versions_calls_validator(self):
+        from kubernator.plugins.k8s_api import K8SResourcePluginMixin
+        mixin = K8SResourcePluginMixin()
+        mixin.validator = MagicMock()
+        mixin.validator.api_versions.return_value = ["v1", "apps/v1"]
+        self.assertEqual(mixin.get_api_versions(), ["v1", "apps/v1"])
+        mixin.validator.api_versions.assert_called_once()

--- a/src/unittest/python/k8s_schema_v3_extensions_tests.py
+++ b/src/unittest/python/k8s_schema_v3_extensions_tests.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+from kubernator.plugins.k8s_schema.base import k8s_format_checker
+from kubernator.plugins.k8s_schema.v3 import V3ValidatorCls
+
+
+def _run(schema, instance):
+    return list(V3ValidatorCls(schema,
+                               format_checker=k8s_format_checker).iter_errors(instance))
+
+
+class ListTypeAtomicTest(unittest.TestCase):
+    SCHEMA = {"type": "array", "x-kubernetes-list-type": "atomic",
+              "items": {"type": "string"}}
+
+    def test_atomic_allows_duplicates(self):
+        self.assertEqual(_run(self.SCHEMA, ["a", "a", "b"]), [])
+
+    def test_atomic_allows_diverse_items(self):
+        self.assertEqual(_run(self.SCHEMA, ["one", "two"]), [])
+
+
+class ListTypeSetTest(unittest.TestCase):
+    SCALAR = {"type": "array", "x-kubernetes-list-type": "set",
+              "items": {"type": "string"}}
+    OBJECT = {"type": "array", "x-kubernetes-list-type": "set",
+              "items": {"type": "object"}}
+
+    def test_set_rejects_duplicate_scalars(self):
+        errs = _run(self.SCALAR, ["a", "b", "a"])
+        self.assertTrue(errs)
+        self.assertTrue(any("duplicates" in str(e.message) for e in errs))
+
+    def test_set_rejects_deep_equal_objects(self):
+        errs = _run(self.OBJECT, [{"x": 1, "y": 2}, {"y": 2, "x": 1}])
+        self.assertTrue(errs)
+
+    def test_set_passes_distinct_items(self):
+        self.assertEqual(_run(self.SCALAR, ["a", "b"]), [])
+
+
+class ListTypeMapTest(unittest.TestCase):
+    SINGLE_KEY = {
+        "type": "array",
+        "x-kubernetes-list-type": "map",
+        "x-kubernetes-list-map-keys": ["name"],
+        "items": {"type": "object",
+                  "properties": {"name": {"type": "string"},
+                                 "value": {"type": "string"}}},
+    }
+    COMPOSITE_KEY = {
+        "type": "array",
+        "x-kubernetes-list-type": "map",
+        "x-kubernetes-list-map-keys": ["protocol", "port"],
+        "items": {"type": "object"},
+    }
+
+    def test_map_rejects_duplicate_single_key(self):
+        errs = _run(self.SINGLE_KEY, [
+            {"name": "a", "value": "1"},
+            {"name": "a", "value": "2"},
+        ])
+        self.assertTrue(errs)
+
+    def test_map_rejects_duplicate_composite_key(self):
+        errs = _run(self.COMPOSITE_KEY, [
+            {"protocol": "TCP", "port": 80},
+            {"protocol": "TCP", "port": 80},
+        ])
+        self.assertTrue(errs)
+
+    def test_map_rejects_missing_key(self):
+        errs = _run(self.SINGLE_KEY, [{"value": "x"}, {"name": "b"}])
+        self.assertTrue(errs)
+        self.assertTrue(any("missing" in str(e.message) for e in errs))
+
+    def test_map_passes_distinct_composite_keys(self):
+        self.assertEqual(_run(self.COMPOSITE_KEY, [
+            {"protocol": "TCP", "port": 80},
+            {"protocol": "UDP", "port": 80},
+        ]), [])
+
+
+class PreserveUnknownFieldsTest(unittest.TestCase):
+    SCHEMA_STRICT = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {"known": {"type": "string"}},
+    }
+    SCHEMA_PRESERVE = {
+        "type": "object",
+        "additionalProperties": False,
+        "x-kubernetes-preserve-unknown-fields": True,
+        "properties": {"known": {"type": "string"}},
+    }
+
+    def test_strict_rejects_unknown(self):
+        self.assertTrue(_run(self.SCHEMA_STRICT, {"known": "x", "extra": 1}))
+
+    def test_preserve_allows_unknown(self):
+        self.assertEqual(_run(self.SCHEMA_PRESERVE,
+                              {"known": "x", "extra": 1}), [])
+
+
+class IntOrStringTest(unittest.TestCase):
+    """Test the type_validator int-or-string logic directly."""
+
+    def test_null_instance_passes(self):
+        schema = {"type": "string", "x-kubernetes-int-or-string": True}
+        self.assertEqual(_run(schema, None), [])
+
+    def test_bool_rejected_for_int_or_string(self):
+        schema = {"type": "string", "x-kubernetes-int-or-string": True}
+        errs = _run(schema, True)
+        self.assertTrue(errs)
+
+    def test_plain_type_mismatch(self):
+        schema = {"type": "integer"}
+        errs = _run(schema, "notanint")
+        self.assertTrue(errs)
+
+
+class ListTypeEdgeCasesTest(unittest.TestCase):
+    def test_list_type_on_non_list_skips_list_check(self):
+        from kubernator.plugins.k8s_schema.v3 import list_type_validator
+        errs = list(list_type_validator(None, "set", "not-a-list", {}))
+        self.assertEqual(errs, [])
+
+    def test_map_with_non_dict_item(self):
+        schema = {"type": "array", "x-kubernetes-list-type": "map",
+                  "x-kubernetes-list-map-keys": ["name"],
+                  "items": {"type": "object"}}
+        errs = _run(schema, [42, "notadict"])
+        self.assertTrue(errs)
+        self.assertTrue(any("not an object" in str(e.message) for e in errs))
+
+    def test_map_with_no_keys_defined(self):
+        schema = {"type": "array", "x-kubernetes-list-type": "map",
+                  "items": {"type": "object"}}
+        self.assertEqual(_run(schema, [{"a": 1}, {"a": 1}]), [])
+
+    def test_embedded_resource_suppresses_additional_properties(self):
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "x-kubernetes-embedded-resource": True,
+            "properties": {"apiVersion": {"type": "string"},
+                           "kind": {"type": "string"}},
+        }
+        self.assertEqual(_run(schema, {"apiVersion": "v1", "kind": "Pod",
+                                       "extra": "ok"}), [])
+
+
+class EmbeddedResourceTest(unittest.TestCase):
+    SCHEMA = {
+        "type": "object",
+        "x-kubernetes-embedded-resource": True,
+    }
+
+    def test_missing_kind_rejected(self):
+        errs = _run(self.SCHEMA, {"apiVersion": "v1",
+                                  "metadata": {"name": "a"}})
+        self.assertTrue(any("'kind'" in str(e.message) for e in errs))
+
+    def test_missing_api_version_rejected(self):
+        errs = _run(self.SCHEMA, {"kind": "Pod",
+                                  "metadata": {"name": "a"}})
+        self.assertTrue(any("'apiVersion'" in str(e.message) for e in errs))
+
+    def test_malformed_name_rejected(self):
+        errs = _run(self.SCHEMA, {"apiVersion": "v1", "kind": "Pod",
+                                  "metadata": {"name": "Bad_Name"}})
+        self.assertTrue(errs)
+
+    def test_valid_embedded(self):
+        self.assertEqual(_run(self.SCHEMA, {"apiVersion": "v1", "kind": "Pod",
+                                            "metadata": {"name": "ok"}}), [])

--- a/src/unittest/python/k8s_schema_v3_tests.py
+++ b/src/unittest/python/k8s_schema_v3_tests.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import unittest
+
+from kubernator.api import PropertyDict
+from kubernator.plugins.k8s_api import K8SResourceDefKey
+from kubernator.plugins.k8s_schema.v3 import (OpenAPIV3Validator,
+                                              _api_version_to_gv_path,
+                                              _gv_path_to_api_version,
+                                              _owning_gv_paths)
+
+
+def _doc(gvk_defs):
+    """Build a minimal v3 sub-document containing the provided
+    `gvk_defs` (mapping schema-name → (group, version, kind, schema))."""
+    schemas = {}
+    for name, (group, version, kind, extra) in gvk_defs.items():
+        schema = {"type": "object",
+                  "x-kubernetes-group-version-kind": [
+                      {"group": group, "version": version, "kind": kind}],
+                  "properties": {
+                      "apiVersion": {"type": "string"},
+                      "kind": {"type": "string"},
+                      "metadata": {"type": "object",
+                                   "properties": {"name": {"type": "string"}},
+                                   "required": ["name"]},
+                  },
+                  "required": ["apiVersion", "kind"]}
+        if extra:
+            schema["properties"].update(extra.get("properties", {}))
+            for k, v in extra.items():
+                if k == "properties":
+                    continue
+                schema[k] = v
+        schemas[name] = schema
+    return {"components": {"schemas": schemas}, "paths": {}}
+
+
+class FakeSource:
+    name = "fake"
+
+    def __init__(self, index, docs):
+        self.index = dict(index)
+        self.docs = dict(docs)
+        self.doc_calls = 0
+
+    def fetch_index(self):
+        return self.index
+
+    def fetch_document(self, key, locator):
+        self.doc_calls += 1
+        return self.docs[key]
+
+
+class GVPathHelpersTest(unittest.TestCase):
+    def test_gv_path_to_api_version_core(self):
+        self.assertEqual(_gv_path_to_api_version("api/v1"), "v1")
+
+    def test_gv_path_to_api_version_apis(self):
+        self.assertEqual(_gv_path_to_api_version("apis/apps/v1"), "apps/v1")
+
+    def test_api_version_to_gv_path_core(self):
+        self.assertEqual(_api_version_to_gv_path("v1"), "api/v1")
+
+    def test_api_version_to_gv_path_apis(self):
+        self.assertEqual(_api_version_to_gv_path("apps/v1"), "apis/apps/v1")
+
+    def test_owning_gv_paths_core(self):
+        self.assertEqual(
+            _owning_gv_paths("io.k8s.api.core.v1.ConfigMap",
+                             ["api/v1", "apis/apps/v1"]),
+            ["api/v1"])
+
+    def test_owning_gv_paths_grouped(self):
+        self.assertEqual(
+            _owning_gv_paths("io.k8s.api.apps.v1.Deployment",
+                             ["api/v1", "apis/apps/v1"]),
+            ["apis/apps/v1"])
+
+    def test_owning_gv_paths_dotted_group(self):
+        self.assertEqual(
+            _owning_gv_paths("io.k8s.api.apiextensions.k8s.io.v1.CustomResourceDefinition",
+                             ["api/v1", "apis/apiextensions.k8s.io/v1"]),
+            ["apis/apiextensions.k8s.io/v1"])
+
+    def test_owning_gv_paths_apimachinery_probes_in_order(self):
+        order = _owning_gv_paths("io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+                                 ["api/v1", "apis/apps/v1", "apis/batch/v1"])
+        self.assertEqual(order[0], "api/v1")
+        self.assertEqual(sorted(order[1:]), ["apis/apps/v1", "apis/batch/v1"])
+
+
+class OpenAPIV3ValidatorLazyFetchTest(unittest.TestCase):
+    def _make(self):
+        core_doc = _doc({
+            "io.k8s.api.core.v1.ConfigMap": (
+                "", "v1", "ConfigMap",
+                {"properties": {
+                    "data": {"type": "object",
+                             "additionalProperties": {"type": "string"}}}}),
+        })
+        apps_doc = _doc({
+            "io.k8s.api.apps.v1.Deployment": (
+                "apps", "v1", "Deployment",
+                {"properties": {
+                    "spec": {"type": "object", "properties": {
+                        "replicas": {"type": "integer"}}}}}),
+        })
+        source = FakeSource(
+            index={"api/v1": "/openapi/v3/api/v1?hash=aaa",
+                   "apis/apps/v1": "/openapi/v3/apis/apps/v1?hash=bbb"},
+            docs={"api/v1": core_doc, "apis/apps/v1": apps_doc})
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[source])
+        v.load()
+        return v, source
+
+    def test_load_does_not_fetch_subdocs(self):
+        _, source = self._make()
+        self.assertEqual(source.doc_calls, 0)
+
+    def test_api_versions_from_index_only(self):
+        v, source = self._make()
+        self.assertEqual(sorted(v.api_versions()), ["apps/v1", "v1"])
+        self.assertEqual(source.doc_calls, 0)
+
+    def test_lookup_triggers_single_fetch(self):
+        v, source = self._make()
+        rdef = v.resource_definitions[K8SResourceDefKey("", "v1", "ConfigMap")]
+        self.assertIsNotNone(rdef)
+        self.assertEqual(source.doc_calls, 1)
+        # Second lookup for same group doesn't re-fetch
+        _ = v.resource_definitions[K8SResourceDefKey("", "v1", "ConfigMap")]
+        self.assertEqual(source.doc_calls, 1)
+        # Different group triggers a new fetch
+        _ = v.resource_definitions[K8SResourceDefKey("apps", "v1", "Deployment")]
+        self.assertEqual(source.doc_calls, 2)
+
+
+class OpenAPIV3ValidatorIterErrorsTest(unittest.TestCase):
+    def _with(self, extra_props):
+        doc = _doc({"io.k8s.api.core.v1.Widget": (
+            "", "v1", "Widget",
+            {"properties": extra_props})})
+        source = FakeSource({"api/v1": "/openapi/v3/api/v1?h=x"},
+                            {"api/v1": doc})
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[source])
+        v.load()
+        rdef = v.resource_definitions[K8SResourceDefKey("", "v1", "Widget")]
+        return v, rdef
+
+    def test_int_or_string_via_format(self):
+        v, rdef = self._with({
+            "port": {"type": "string", "format": "int-or-string"}})
+        m_int = {"apiVersion": "v1", "kind": "Widget",
+                 "metadata": {"name": "w"}, "port": 8080}
+        m_str = {"apiVersion": "v1", "kind": "Widget",
+                 "metadata": {"name": "w"}, "port": "8080"}
+        self.assertEqual(list(v.iter_errors(m_int, rdef)), [])
+        self.assertEqual(list(v.iter_errors(m_str, rdef)), [])
+
+    def test_int_or_string_via_extension(self):
+        v, rdef = self._with({
+            "port": {"type": "string", "x-kubernetes-int-or-string": True}})
+        m_int = {"apiVersion": "v1", "kind": "Widget",
+                 "metadata": {"name": "w"}, "port": 8080}
+        m_str = {"apiVersion": "v1", "kind": "Widget",
+                 "metadata": {"name": "w"}, "port": "8080"}
+        self.assertEqual(list(v.iter_errors(m_int, rdef)), [])
+        self.assertEqual(list(v.iter_errors(m_str, rdef)), [])
+
+    def test_oneOf_rejects_mismatch(self):
+        # OAS30 honors oneOf natively (unlike v2 swagger which drops it)
+        v, rdef = self._with({
+            "size": {
+                "oneOf": [
+                    {"type": "string", "enum": ["small", "medium", "large"]},
+                    {"type": "integer"},
+                ]}})
+        bad = {"apiVersion": "v1", "kind": "Widget",
+               "metadata": {"name": "w"}, "size": True}
+        errs = list(v.iter_errors(bad, rdef))
+        self.assertTrue(errs)
+
+
+class GVPathEdgeCasesTest(unittest.TestCase):
+    def test_gv_path_to_api_version_unknown_prefix(self):
+        self.assertIsNone(_gv_path_to_api_version("unknown/v1"))
+
+    def test_owning_gv_paths_no_match_falls_back_to_ordered(self):
+        result = _owning_gv_paths("io.k8s.api.unknown.v1.Widget",
+                                  ["api/v1", "apis/batch/v1"])
+        self.assertEqual(result[0], "api/v1")
+        self.assertIn("apis/batch/v1", result)
+
+
+class OpenAPIV3ValidatorCrossDocRefTest(unittest.TestCase):
+    def test_cross_doc_ref_triggers_fetch(self):
+        core_doc = {
+            "components": {"schemas": {
+                "io.k8s.api.core.v1.ConfigMap": {
+                    "type": "object",
+                    "x-kubernetes-group-version-kind": [
+                        {"group": "", "version": "v1", "kind": "ConfigMap"}],
+                    "properties": {
+                        "apiVersion": {"type": "string"},
+                        "kind": {"type": "string"},
+                        "metadata": {"type": "object",
+                                     "properties": {"name": {"type": "string"}},
+                                     "required": ["name"]},
+                        "ref": {"$ref": "#/components/schemas/io.k8s.api.apps.v1.Deployment"},
+                    },
+                    "required": ["apiVersion", "kind"],
+                },
+            }},
+            "paths": {},
+        }
+        apps_doc = _doc({
+            "io.k8s.api.apps.v1.Deployment": (
+                "apps", "v1", "Deployment", None),
+        })
+        source = FakeSource(
+            index={"api/v1": "/v3/api/v1?h=x",
+                   "apis/apps/v1": "/v3/apis/apps/v1?h=y"},
+            docs={"api/v1": core_doc, "apis/apps/v1": apps_doc})
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[source])
+        v.load()
+        _ = v.resource_definitions[K8SResourceDefKey("", "v1", "ConfigMap")]
+        self.assertEqual(source.doc_calls, 2)
+
+    def test_populate_group_without_load_raises(self):
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[])
+        v._index = {"api/v1": "loc"}
+        with self.assertRaises(RuntimeError):
+            v._populate_group("api/v1")
+
+    def test_ensure_group_unknown_raises(self):
+        source = FakeSource({"api/v1": "x"}, {"api/v1": _doc({})})
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[source])
+        v.load()
+        with self.assertRaises(KeyError):
+            v._ensure_group_loaded("unknown", "v1")
+
+
+class OpenAPIV3ValidatorLoadFallbackTest(unittest.TestCase):
+    def test_primary_failure_falls_through_to_secondary(self):
+        class Broken:
+            name = "broken"
+
+            def fetch_index(self):
+                raise RuntimeError("boom")
+
+            def fetch_document(self, *a, **k):
+                raise AssertionError("should not be called")
+
+        ok = FakeSource({"api/v1": "x"}, {"api/v1": _doc({})})
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[Broken(), ok])
+        v.load()
+        self.assertIs(v._active_source, ok)
+
+    def test_all_sources_failing_raises(self):
+        class Broken:
+            name = "broken"
+
+            def fetch_index(self):
+                raise RuntimeError("nope")
+
+        ctx = PropertyDict()
+        ctx.k8s = dict(server_git_version="v1.30.0")
+        v = OpenAPIV3Validator(ctx, sources=[Broken(), Broken()])
+        with self.assertRaises(RuntimeError):
+            v.load()


### PR DESCRIPTION
## Summary

Extracts all OpenAPI validation out of `k8s.py` / `k8s_api.py` into a new `kubernator/plugins/k8s_schema/` package, and adds an OpenAPI v3 validator with client-side CEL rule evaluation as the default on clusters ≥ 1.27.

- **`k8s_api.py` no longer does validation** — `K8SResourcePluginMixin` holds a single `self.validator` and delegates every manifest check (minimal envelope → rdef lookup → full schema → CEL rules) to it. Dependency graph is one-way: `k8s_schema → k8s_api`.
- **Two validators behind a factory.** `SwaggerV2Validator` preserves current behaviour (swagger.json + OAS31). `OpenAPIV3Validator` is new: cluster-first `/openapi/v3` discovery with GitHub fallback, lazy per-group fetch, transitive `$ref` closure across group documents.
- **K8s extensions enforced client-side** under v3: `x-kubernetes-list-type` (`atomic` / `set` / `map` with `list-map-keys`), `-preserve-unknown-fields`, `-embedded-resource`, `-int-or-string`.
- **CEL rules evaluated client-side.** Lazy-compiled, cached by rule text for the run. Ports of the K8s CEL libraries — `lists`, `regex`, `format.named(...)`, `quantity`, `IP`, `CIDR` — plus a compatibility shim for `optional.of` / `optional.none` / `hasValue` / `value` / `orValue` so `optionalSelf` / `optionalOldSelf` work. Transition rules fire in the apply path against the cluster's current state.
- **Selection.** `ktor.k8s.register()` gains `openapi_version` (`auto` / `v2` / `v3`) and `openapi_source` (`auto` / `cluster` / `github`) kwargs (also readable from context). `auto` gates on server minor ≥ 1.27 and falls back to v2 on any v3 failure. `istio.py` is migrated to the same factory.

New dep: `cel-python ~=0.5`.

## Test plan

- [x] 111 unit tests (v2 parity; v3 lazy fetch; api_versions without sub-doc fetch; source fallback; every extension keyword; CEL walker + evaluator; 7 extension libraries; factory selection / version gate / explicit-kwarg override)
- [x] `issue_openapi_v3_tests.py` — end-to-end on a real kind cluster: applies a CRD with `x-kubernetes-validations` + `list-type: map`, then applies a good and a bad Widget. Client-side rejection confirmed: `x-kubernetes-list-type` handler and the CEL `replicas must not exceed maxReplicas` rule both fire before any request hits the server.
- [x] `issue_35_tests.py` regression — 12 subtests (2 K8s versions × 3 field_validation modes × 2 warn_fatal flags) all green. The k8s_api → validator split hasn't regressed the existing CRD + field-validation path.
- [x] `flake8` clean