### PR TITLE
Add KubeOne plugin: cluster lifecycle management via kubeadm over SSH

### DIFF
--- a/src/integrationtest/python/kubeone_dry_run/.kubernator.py
+++ b/src/integrationtest/python/kubeone_dry_run/.kubernator.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+ktor.app.register_plugin("kubeone", version="1.9.1")

--- a/src/integrationtest/python/kubeone_dry_run/cluster.kubeone.yaml
+++ b/src/integrationtest/python/kubeone_dry_run/cluster.kubeone.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubeone.k8c.io/v1beta2
+kind: KubeOneCluster
+name: test-cluster
+versions:
+  kubernetes: "1.31.0"
+cloudProvider:
+  none: {}
+controlPlane:
+  hosts:
+    - publicAddress: 192.168.1.10
+      privateAddress: 192.168.1.10
+      sshUsername: admin
+      sshPort: 22
+    - publicAddress: 192.168.1.11
+      privateAddress: 192.168.1.11
+      sshUsername: admin
+      sshPort: 22

--- a/src/integrationtest/python/kubeone_dry_run_tests.py
+++ b/src/integrationtest/python/kubeone_dry_run_tests.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2025 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+from test_support import IntegrationTestSupport, unittest
+
+unittest  # noqa
+# Above import must be first
+
+from pathlib import Path  # noqa: E402
+
+
+class KubeOneDryRunTest(IntegrationTestSupport):
+    def test_manifest_discovery_and_validation(self):
+        test_dir = Path(__file__).parent / "kubeone_dry_run"
+        self.run_module_test("kubernator", "-p", str(test_dir), "-v", "TRACE", "dump")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/python/kubernator/plugins/kubeone.py
+++ b/src/main/python/kubernator/plugins/kubeone.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2025 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import json
+import logging
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+from shutil import which
+
+import yaml
+
+from kubernator.api import (KubernatorPlugin, Globs, StripNL,
+                            scan_dir,
+                            load_file,
+                            FileType,
+                            TemplateEngine,
+                            get_golang_os,
+                            get_golang_machine,
+                            prepend_os_path,
+                            )
+
+logger = logging.getLogger("kubernator.kubeone")
+proc_logger = logger.getChild("proc")
+stdout_logger = StripNL(proc_logger.info)
+stderr_logger = StripNL(proc_logger.warning)
+
+
+class KubeOnePlugin(KubernatorPlugin):
+    logger = logger
+
+    _name = "kubeone"
+
+    def __init__(self):
+        self.context = None
+        self.kubeone_file = None
+        self.kubeone_dir = None
+        self._work_dir = None
+        self._manifest_path = None
+        self.template_engine = TemplateEngine(logger)
+
+        super().__init__()
+
+    def set_context(self, context):
+        self.context = context
+
+    def stanza(self):
+        stanza = [self.kubeone_file]
+        if self._manifest_path:
+            stanza.extend(["--manifest", str(self._manifest_path)])
+        if logger.getEffectiveLevel() < logging.INFO:
+            stanza.append("--verbose")
+        return stanza
+
+    def register(self, version=None):
+        context = self.context
+
+        context.app.register_plugin("kubeconfig")
+
+        self._work_dir = tempfile.TemporaryDirectory()
+        context.app.register_cleanup(self._work_dir)
+
+        if version:
+            url = (f"https://github.com/kubermatic/kubeone/releases/download/"
+                   f"v{version}/kubeone_{version}_{get_golang_os()}_{get_golang_machine()}.zip")
+            dl_file, _ = context.app.download_remote_file(logger, url, "bin")
+            dl_file = str(dl_file)
+            self.kubeone_dir = tempfile.TemporaryDirectory()
+            context.app.register_cleanup(self.kubeone_dir)
+
+            kubeone_zip = zipfile.ZipFile(dl_file)
+            kubeone_zip.extractall(self.kubeone_dir.name)
+
+            kubeone_file = Path(self.kubeone_dir.name) / "kubeone"
+            if not kubeone_file.exists():
+                for p in Path(self.kubeone_dir.name).rglob("kubeone"):
+                    if p.is_file() and p.name == "kubeone":
+                        kubeone_file = p
+                        break
+                else:
+                    raise RuntimeError("kubeone binary not found in the downloaded archive")
+
+            os.chmod(kubeone_file, 0o500)
+            prepend_os_path(str(kubeone_file.parent))
+        else:
+            kubeone_file = which("kubeone")
+            if not kubeone_file:
+                raise RuntimeError("`kubeone` cannot be found and no version has been specified")
+
+            logger.debug("Found KubeOne in %r", kubeone_file)
+
+        self.kubeone_file = str(kubeone_file)
+
+        version_out = context.app.run_capturing_out(
+            [self.kubeone_file, "version"], stderr_logger)
+        try:
+            version = json.loads(version_out)["kubeone"]["gitVersion"].lstrip("v")
+        except (json.JSONDecodeError, KeyError):
+            version = version_out.strip()
+
+        kubeconfig_path = str(Path(self._work_dir.name) / "config")
+
+        context.globals.kubeone = dict(version=version,
+                                       kubeone_file=self.kubeone_file,
+                                       stanza=self.stanza,
+                                       kubeconfig=kubeconfig_path,
+                                       apply=self.apply,
+                                       status=self.status,
+                                       kubeconfig_export=self.kubeconfig_export,
+                                       reset=self.reset,
+                                       )
+
+        logger.info("Found KubeOne version %s at %s", version, self.kubeone_file)
+
+    def handle_init(self):
+        context = self.context
+        context.kubeone = dict(default_includes=Globs(["*.kubeone.yaml", "*.kubeone.yml"], True),
+                               default_excludes=Globs([".*"], True),
+                               )
+
+    def handle_start(self):
+        context = self.context
+        try:
+            context.k8s.default_excludes.add("*.kubeone.yaml")
+            context.k8s.default_excludes.add("*.kubeone.yml")
+        except AttributeError:
+            pass
+
+    def handle_before_dir(self, cwd: Path):
+        context = self.context
+        context.kubeone.default_includes = Globs(context.kubeone.default_includes)
+        context.kubeone.default_excludes = Globs(context.kubeone.default_excludes)
+        context.kubeone.includes = Globs(context.kubeone.default_includes)
+        context.kubeone.excludes = Globs(context.kubeone.default_excludes)
+
+    def handle_after_dir(self, cwd: Path):
+        context = self.context
+        ko = context.kubeone
+
+        for f in scan_dir(logger, cwd, lambda d: d.is_file(), ko.excludes, ko.includes):
+            p = cwd / f.name
+            display_p = context.app.display_path(p)
+
+            if self._manifest_path:
+                logger.warning("Multiple KubeOne manifests found; %s overrides previous manifest", display_p)
+
+            logger.debug("Detected KubeOne manifest in %s", display_p)
+
+            manifests = load_file(logger, p, FileType.YAML, display_p,
+                                  self.template_engine,
+                                  {"ktor": context})
+
+            manifest_tmp = Path(self._work_dir.name) / "kubeone.yaml"
+            with manifest_tmp.open("w") as mf:
+                for manifest in manifests:
+                    if manifest:
+                        yaml.dump(manifest, mf, default_flow_style=False)
+
+            self._manifest_path = manifest_tmp
+
+            resolved = context.app.run_capturing_out(
+                self.stanza() + ["config", "dump"],
+                stderr_logger)
+            logger.info("Validated KubeOne manifest from %s", display_p)
+            logger.debug("Resolved KubeOne manifest:\n%s", resolved)
+
+    def _tfjson_args(self):
+        context = self.context
+        try:
+            tf = context.tf
+        except AttributeError:
+            return []
+
+        tf_data = {}
+        for k in dir(tf):
+            tf_data[k] = {"value": tf[k]}
+
+        tf_json_path = Path(self._work_dir.name) / "tf.json"
+        with tf_json_path.open("w") as f:
+            json.dump(tf_data, f)
+        return ["--tfjson", str(tf_json_path)]
+
+    def apply(self):
+        context = self.context
+        if not self._manifest_path:
+            raise RuntimeError("No KubeOne manifest found")
+
+        cmd = context.app.args.command
+        dry_run = context.app.args.dry_run
+
+        if cmd != "apply" or dry_run:
+            status_msg = " (dump only)" if cmd == "dump" else " (dry run)"
+            logger.info("Would run kubeone apply%s", status_msg)
+        else:
+            apply_cmd = self.stanza() + self._tfjson_args() + ["apply", "--auto-approve"]
+            context.app.run(apply_cmd, stdout_logger, stderr_logger).wait()
+            self.kubeconfig_export()
+
+    def kubeconfig_export(self):
+        context = self.context
+        if not self._manifest_path:
+            raise RuntimeError("No KubeOne manifest found")
+
+        kubeconfig_out = context.app.run_capturing_out(
+            self.stanza() + self._tfjson_args() + ["kubeconfig"],
+            stderr_logger)
+
+        kubeconfig_path = context.kubeone.kubeconfig
+        with open(kubeconfig_path, "w") as f:
+            f.write(kubeconfig_out)
+
+        context.kubeconfig.set(kubeconfig_path)
+        logger.info("Exported kubeconfig to %s", kubeconfig_path)
+
+    def status(self):
+        context = self.context
+        if not self._manifest_path:
+            raise RuntimeError("No KubeOne manifest found")
+
+        context.app.run(
+            self.stanza() + self._tfjson_args() + ["status"],
+            stdout_logger, stderr_logger).wait()
+
+    def reset(self):
+        context = self.context
+        if not self._manifest_path:
+            raise RuntimeError("No KubeOne manifest found")
+
+        cmd = context.app.args.command
+        dry_run = context.app.args.dry_run
+
+        if cmd != "apply" or dry_run:
+            status_msg = " (dump only)" if cmd == "dump" else " (dry run)"
+            logger.info("Would run kubeone reset%s", status_msg)
+        else:
+            reset_cmd = self.stanza() + self._tfjson_args() + ["reset", "--auto-approve"]
+            context.app.run(reset_cmd, stdout_logger, stderr_logger).wait()
+
+    def __repr__(self):
+        return "KubeOne Plugin"

--- a/src/unittest/python/kubeone_tests.py
+++ b/src/unittest/python/kubeone_tests.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2025 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from kubernator.api import PropertyDict, Globs
+from kubernator.plugins.kubeone import KubeOnePlugin
+
+
+def _make_context(**overrides):
+    global_ctx = PropertyDict()
+    global_ctx.globals = global_ctx
+    ctx = PropertyDict(_parent=global_ctx)
+    ctx.app = dict(
+        register_plugin=MagicMock(),
+        register_cleanup=MagicMock(),
+        download_remote_file=MagicMock(),
+        run=MagicMock(),
+        run_capturing_out=MagicMock(),
+        display_path=lambda p: str(p),
+        args=types.SimpleNamespace(command="dump", dry_run=True),
+    )
+    ctx.kubeconfig = dict(set=MagicMock())
+    for k, v in overrides.items():
+        setattr(ctx, k, v)
+    return ctx
+
+
+class KubeOnePluginRegisterTest(unittest.TestCase):
+    def test_register_system_binary_not_found(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+
+        with patch("kubernator.plugins.kubeone.which", return_value=None):
+            with self.assertRaises(RuntimeError) as cm:
+                plugin.register()
+            self.assertIn("kubeone", str(cm.exception))
+
+    def test_register_system_binary_found(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+
+        version_json = json.dumps({
+            "kubeone": {"gitVersion": "v1.9.1", "gitCommit": "abc123"},
+            "machine_controller": {"gitVersion": "v1.60.0"}
+        })
+
+        with patch("kubernator.plugins.kubeone.which", return_value="/usr/bin/kubeone"):
+            ctx.app["run_capturing_out"] = MagicMock(return_value=version_json)
+            plugin.register()
+
+        self.assertEqual(plugin.kubeone_file, "/usr/bin/kubeone")
+        self.assertEqual(ctx.kubeone.version, "1.9.1")
+        ctx.app["register_plugin"].assert_called_once_with("kubeconfig")
+
+    def test_register_version_fallback_on_invalid_json(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+
+        with patch("kubernator.plugins.kubeone.which", return_value="/usr/bin/kubeone"):
+            ctx.app["run_capturing_out"] = MagicMock(return_value="kubeone version 1.8.0")
+            plugin.register()
+
+        self.assertEqual(ctx.kubeone.version, "kubeone version 1.8.0")
+
+    def test_register_download_version(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+
+        work_dir = tempfile.TemporaryDirectory()
+        kubeone_bin = Path(work_dir.name) / "kubeone"
+        kubeone_bin.touch()
+
+        zip_dir = tempfile.TemporaryDirectory()
+        zip_path = Path(zip_dir.name) / "kubeone.zip"
+        import zipfile
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.write(kubeone_bin, "kubeone")
+
+        ctx.app["download_remote_file"] = MagicMock(return_value=(zip_path, False))
+
+        version_json = json.dumps({
+            "kubeone": {"gitVersion": "v1.9.1"},
+            "machine_controller": {"gitVersion": "v1.60.0"}
+        })
+        ctx.app["run_capturing_out"] = MagicMock(return_value=version_json)
+
+        try:
+            plugin.register(version="1.9.1")
+
+            ctx.app["download_remote_file"].assert_called_once()
+            call_args = ctx.app["download_remote_file"].call_args
+            url = call_args[0][1]
+            self.assertIn("kubeone_1.9.1_", url)
+            self.assertIn(".zip", url)
+            self.assertEqual(ctx.kubeone.version, "1.9.1")
+        finally:
+            work_dir.cleanup()
+            zip_dir.cleanup()
+            if plugin._work_dir:
+                plugin._work_dir.cleanup()
+            if plugin.kubeone_dir:
+                plugin.kubeone_dir.cleanup()
+
+
+class KubeOnePluginStanzaTest(unittest.TestCase):
+    def test_stanza_without_manifest(self):
+        plugin = KubeOnePlugin()
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = None
+        self.assertEqual(plugin.stanza(), ["/usr/bin/kubeone"])
+
+    def test_stanza_with_manifest(self):
+        plugin = KubeOnePlugin()
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+        stanza = plugin.stanza()
+        self.assertEqual(stanza[0], "/usr/bin/kubeone")
+        self.assertIn("--manifest", stanza)
+        self.assertIn("/tmp/kubeone.yaml", stanza)
+
+
+class KubeOnePluginInitTest(unittest.TestCase):
+    def test_handle_init_sets_defaults(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin.handle_init()
+
+        includes = ctx.kubeone.default_includes
+        self.assertIn("*.kubeone.yaml", includes)
+        self.assertIn("*.kubeone.yml", includes)
+
+    def test_handle_before_dir_resets_globs(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin.handle_init()
+
+        plugin.handle_before_dir(Path("/some/dir"))
+        self.assertIsNotNone(ctx.kubeone.includes)
+        self.assertIsNotNone(ctx.kubeone.excludes)
+
+
+class KubeOnePluginApplyTest(unittest.TestCase):
+    def _make_plugin(self, command="apply", dry_run=False):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        ctx.app["args"] = types.SimpleNamespace(command=command, dry_run=dry_run)
+        plugin.set_context(ctx)
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+        plugin._work_dir = tempfile.TemporaryDirectory()
+        kubeconfig_path = str(Path(plugin._work_dir.name) / "config")
+        ctx.globals.kubeone = dict(kubeconfig=kubeconfig_path)
+        return plugin, ctx
+
+    def test_apply_raises_without_manifest(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin._manifest_path = None
+        with self.assertRaises(RuntimeError) as cm:
+            plugin.apply()
+        self.assertIn("No KubeOne manifest", str(cm.exception))
+
+    def test_apply_dry_run_does_not_execute(self):
+        plugin, ctx = self._make_plugin(command="apply", dry_run=True)
+        try:
+            mock_run = MagicMock()
+            ctx.app["run"] = mock_run
+            plugin.apply()
+            mock_run.assert_not_called()
+        finally:
+            plugin._work_dir.cleanup()
+
+    def test_apply_dump_mode_does_not_execute(self):
+        plugin, ctx = self._make_plugin(command="dump", dry_run=False)
+        try:
+            mock_run = MagicMock()
+            ctx.app["run"] = mock_run
+            plugin.apply()
+            mock_run.assert_not_called()
+        finally:
+            plugin._work_dir.cleanup()
+
+    def test_apply_executes_with_auto_approve(self):
+        plugin, ctx = self._make_plugin(command="apply", dry_run=False)
+        try:
+            mock_runner = MagicMock()
+            mock_runner.wait = MagicMock()
+            mock_run = MagicMock(return_value=mock_runner)
+            ctx.app["run"] = mock_run
+            ctx.app["run_capturing_out"] = MagicMock(return_value="apiVersion: v1\nkind: Config\n")
+
+            plugin.apply()
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            self.assertIn("apply", cmd)
+            self.assertIn("--auto-approve", cmd)
+        finally:
+            plugin._work_dir.cleanup()
+
+
+class KubeOnePluginResetTest(unittest.TestCase):
+    def test_reset_raises_without_manifest(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin._manifest_path = None
+        with self.assertRaises(RuntimeError) as cm:
+            plugin.reset()
+        self.assertIn("No KubeOne manifest", str(cm.exception))
+
+    def test_reset_dry_run_does_not_execute(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        ctx.app["args"] = types.SimpleNamespace(command="apply", dry_run=True)
+        plugin.set_context(ctx)
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+
+        mock_run = MagicMock()
+        ctx.app["run"] = mock_run
+        plugin.reset()
+        mock_run.assert_not_called()
+
+    def test_reset_executes_with_auto_approve(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        ctx.app["args"] = types.SimpleNamespace(command="apply", dry_run=False)
+        plugin.set_context(ctx)
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+        plugin._work_dir = tempfile.TemporaryDirectory()
+
+        try:
+            mock_runner = MagicMock()
+            mock_runner.wait = MagicMock()
+            mock_run = MagicMock(return_value=mock_runner)
+            ctx.app["run"] = mock_run
+
+            plugin.reset()
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            self.assertIn("reset", cmd)
+            self.assertIn("--auto-approve", cmd)
+        finally:
+            plugin._work_dir.cleanup()
+
+
+class KubeOnePluginTfJsonTest(unittest.TestCase):
+    def test_tfjson_args_without_terraform(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        self.assertEqual(plugin._tfjson_args(), [])
+
+    def test_tfjson_args_with_terraform(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        ctx.tf = {}
+        ctx.tf["cluster_name"] = "test-cluster"
+        ctx.tf["api_endpoint"] = "10.0.0.1"
+        plugin.set_context(ctx)
+        plugin._work_dir = tempfile.TemporaryDirectory()
+
+        try:
+            args = plugin._tfjson_args()
+            self.assertEqual(len(args), 2)
+            self.assertEqual(args[0], "--tfjson")
+
+            with open(args[1]) as f:
+                tf_data = json.load(f)
+            self.assertEqual(tf_data["cluster_name"]["value"], "test-cluster")
+            self.assertEqual(tf_data["api_endpoint"]["value"], "10.0.0.1")
+        finally:
+            plugin._work_dir.cleanup()
+
+
+class KubeOnePluginKubeconfigExportTest(unittest.TestCase):
+    def test_kubeconfig_export_raises_without_manifest(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin._manifest_path = None
+        with self.assertRaises(RuntimeError) as cm:
+            plugin.kubeconfig_export()
+        self.assertIn("No KubeOne manifest", str(cm.exception))
+
+    def test_kubeconfig_export_writes_and_registers(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+        plugin._work_dir = tempfile.TemporaryDirectory()
+
+        kubeconfig_content = "apiVersion: v1\nkind: Config\nclusters: []\n"
+        kubeconfig_path = str(Path(plugin._work_dir.name) / "config")
+        ctx.globals.kubeone = dict(kubeconfig=kubeconfig_path)
+        ctx.app["run_capturing_out"] = MagicMock(return_value=kubeconfig_content)
+
+        try:
+            plugin.kubeconfig_export()
+
+            with open(kubeconfig_path) as f:
+                self.assertEqual(f.read(), kubeconfig_content)
+            ctx.kubeconfig["set"].assert_called_once_with(kubeconfig_path)
+        finally:
+            plugin._work_dir.cleanup()
+
+
+class KubeOnePluginStatusTest(unittest.TestCase):
+    def test_status_raises_without_manifest(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin._manifest_path = None
+        with self.assertRaises(RuntimeError) as cm:
+            plugin.status()
+        self.assertIn("No KubeOne manifest", str(cm.exception))
+
+    def test_status_runs_command(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin.kubeone_file = "/usr/bin/kubeone"
+        plugin._manifest_path = Path("/tmp/kubeone.yaml")
+        plugin._work_dir = tempfile.TemporaryDirectory()
+
+        try:
+            mock_runner = MagicMock()
+            mock_runner.wait = MagicMock()
+            mock_run = MagicMock(return_value=mock_runner)
+            ctx.app["run"] = mock_run
+
+            plugin.status()
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            self.assertIn("status", cmd)
+        finally:
+            plugin._work_dir.cleanup()
+
+
+class KubeOnePluginHandleStartTest(unittest.TestCase):
+    def test_excludes_kubeone_from_k8s_when_present(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        ctx.k8s = dict(default_excludes=Globs([".*"]))
+        plugin.set_context(ctx)
+
+        plugin.handle_start()
+
+        excludes = ctx.k8s.default_excludes
+        self.assertIn("*.kubeone.yaml", excludes)
+        self.assertIn("*.kubeone.yml", excludes)
+
+    def test_no_error_without_k8s_plugin(self):
+        plugin = KubeOnePlugin()
+        ctx = _make_context()
+        plugin.set_context(ctx)
+        plugin.handle_start()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `kubeone` plugin integrating Kubermatic KubeOne for provisioning Kubernetes clusters on bare-metal/VM hosts via kubeadm over SSH
- Binary download from GitHub releases (ZIP) or system PATH lookup, following the terraform/helm plugin pattern
- Auto-discovers `*.kubeone.yaml` manifests during directory walk, templates with Jinja2, validates via `kubeone config dump`
- Exposes `apply()`, `reset()`, `status()`, `kubeconfig_export()` on `context.globals.kubeone`
- Respects Kubernator dry-run semantics (`dump` mode / `--yes` flag)
- Optional terraform state pass-through via `--tfjson` when terraform plugin is loaded
- Excludes `*.kubeone.yaml` from k8s plugin processing when both are registered
- Warns when multiple KubeOne manifests are found (last one wins)

## Test plan

- [x] 19 unit tests covering registration, stanza building, apply/reset dry-run, tfjson args, kubeconfig export, status, k8s excludes
- [x] Integration test downloading real KubeOne 1.9.1 binary, discovering and validating a bare-metal manifest via `config dump`