### PR TITLE
Fix test-only JSON patches treated as non-empty mutations

### DIFF
--- a/src/main/python/kubernator/plugins/k8s.py
+++ b/src/main/python/kubernator/plugins/k8s.py
@@ -1333,6 +1333,7 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
 
     def _filter_resource_patch(self, patch: Iterable[Mapping], excludes: Iterable[re.compile]):
         result = []
+        has_mutations = False
         for op in patch:
             if op["op"] != "test":
                 path = op["path"]
@@ -1344,7 +1345,10 @@ class KubernetesPlugin(KubernatorPlugin, K8SResourcePluginMixin):
                         break
                 if excluded:
                     continue
+                has_mutations = True
             result.append(op)
+        if not has_mutations:
+            return []
         return result
 
     def _setup_k8s_client(self):

--- a/src/unittest/python/k8s_filter_patch_tests.py
+++ b/src/unittest/python/k8s_filter_patch_tests.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+#   Copyright 2020 Express Systems USA, Inc
+#   Copyright 2026 Karellen, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+from gevent.monkey import patch_all, is_anything_patched
+
+if not is_anything_patched():
+    patch_all()
+
+import re
+import unittest
+from unittest.mock import MagicMock
+
+
+class K8sFilterResourcePatchTest(unittest.TestCase):
+    def _make_plugin(self):
+        plugin = MagicMock()
+        return plugin
+
+    def test_test_only_patch_returns_empty(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        patch = [
+            {"op": "test", "path": "/metadata/uid", "value": "abc-123"},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": "42"},
+        ]
+
+        result = KubernetesPlugin._filter_resource_patch(plugin, patch, [])
+
+        self.assertEqual(result, [])
+
+    def test_patch_with_mutations_preserves_tests_and_mutations(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        patch = [
+            {"op": "replace", "path": "/data/key", "value": "new"},
+            {"op": "test", "path": "/metadata/uid", "value": "abc-123"},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": "42"},
+        ]
+
+        result = KubernetesPlugin._filter_resource_patch(plugin, patch, [])
+
+        self.assertEqual(result, patch)
+
+    def test_excluded_mutations_leave_only_tests_returns_empty(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        patch = [
+            {"op": "replace", "path": "/data/key", "value": "new"},
+            {"op": "add", "path": "/data/other", "value": "val"},
+            {"op": "test", "path": "/metadata/uid", "value": "abc-123"},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": "42"},
+        ]
+        excludes = [re.compile(r"/data/.*")]
+
+        result = KubernetesPlugin._filter_resource_patch(plugin, patch, excludes)
+
+        self.assertEqual(result, [])
+
+    def test_partial_exclude_preserves_remaining_mutations(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+        patch = [
+            {"op": "replace", "path": "/data/key", "value": "new"},
+            {"op": "replace", "path": "/spec/replicas", "value": 3},
+            {"op": "test", "path": "/metadata/uid", "value": "abc-123"},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": "42"},
+        ]
+        excludes = [re.compile(r"/data/.*")]
+
+        result = KubernetesPlugin._filter_resource_patch(plugin, patch, excludes)
+
+        self.assertEqual(result, [
+            {"op": "replace", "path": "/spec/replicas", "value": 3},
+            {"op": "test", "path": "/metadata/uid", "value": "abc-123"},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": "42"},
+        ])
+
+    def test_empty_patch_returns_empty(self):
+        from kubernator.plugins.k8s import KubernetesPlugin
+
+        plugin = self._make_plugin()
+
+        result = KubernetesPlugin._filter_resource_patch(plugin, [], [])
+
+        self.assertEqual(result, [])


### PR DESCRIPTION
## Summary

- **Bug:** `_filter_resource_patch` always preserves `test` ops (uid/resourceVersion guards), so when all mutation ops are filtered out or absent, the patch list is still truthy. This causes spurious "Patching resource" log entries in dump mode and unnecessary no-op PATCH API calls in apply mode.
- **Fix:** Track whether any mutation (non-`test`) ops survive filtering. Return an empty list when only `test` ops remain, since test-only JSON Patches are no-ops.
- **Tests:** Added `k8s_filter_patch_tests.py` covering: test-only patch returns empty, mutations preserved with tests, all mutations excluded returns empty, partial exclude preserves remaining, empty input returns empty.

## Test plan

- [x] All existing unit tests pass (`pyb -vX run_unit_tests`)
- [x] New `k8s_filter_patch_tests.py` covers the fix